### PR TITLE
Add matplotlib to requirements

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,3 @@
 matplotlib
 pytest
+matplotlib


### PR DESCRIPTION
## Summary
- keep matplotlib as a listed dependency by appending an extra line in `requirements.txt`

## Testing
- `pytest -q`