### PR TITLE
Update PoR/ΔE/grv collector

### DIFF
--- a/por_deltae_grv_collector.py
+++ b/por_deltae_grv_collector.py
@@ -1,5 +1,13 @@
 #!/usr/bin/env python3
-"""Lightweight PoR/ΔE/grv collector utility."""
+"""PoR・ΔE・grv統合評価型Q&Aロガー.
+
+This module runs a simple Q&A cycle where a user supplied question is
+answered by a dummy AI function.  Each turn calculates three metrics:
+PoR (Proof of Resonance), ΔE (difference between consecutive answers)
+and grv (vocabulary gravity).  The metrics are combined to decide
+whether a record should be stored in history.  At the end of the run
+all adopted records are written to a CSV file.
+"""
 
 from __future__ import annotations
 
@@ -9,23 +17,26 @@ import time
 from dataclasses import dataclass, asdict, field
 from difflib import SequenceMatcher
 from pathlib import Path
-from typing import List, Dict, Any, Tuple
-import random
-from por_trigger import por_trigger
+from typing import Any, Dict, List, Tuple
 
+from por_trigger import por_trigger
 import grv_scoring
 
 # ---------------------------------------------------------------------------
-# metric weights and threshold
+# Scoring weights and thresholds
 # ---------------------------------------------------------------------------
+# weight for PoR component in overall score
 W_POR: float = 0.4
+# weight for (1 - ΔE) component in overall score
 W_DE: float = 0.4
+# weight for grv component in overall score
 W_GRV: float = 0.2
+# threshold for adopting a record into history
 ADOPT_TH: float = 0.45
 
 
 # ---------------------------------------------------------------------------
-# basic metric helpers
+# Basic helpers
 # ---------------------------------------------------------------------------
 
 def get_ai_response(question: str) -> str:
@@ -33,61 +44,61 @@ def get_ai_response(question: str) -> str:
     return f"Answer for '{question}'"
 
 
-def compute_semantic_similarity(text1: str, text2: str) -> float:
-    """Return similarity ratio between two texts."""
+def _similarity(text1: str, text2: str) -> float:
+    """Return a similarity ratio between two strings."""
     return SequenceMatcher(None, text1, text2).ratio()
 
 
+# ---------------------------------------------------------------------------
+# Metric calculations
+# ---------------------------------------------------------------------------
+
 def estimate_ugh_params(question: str, history: List["QaRecord"]) -> Dict[str, Any]:
-    """Estimate UGH parameters from the question text and history length."""
+    """Return automatic UGHer parameters based on the question and history."""
     q_len = len(question)
     h_len = len(history)
-
     q = min(1.0, q_len / 50.0)
     s = min(1.0, 0.5 + 0.05 * h_len)
     t = 0.5 + min(0.5, q_len / 100.0)
-    phi_C = round(0.8 + random.uniform(-0.05, 0.05), 3)
-    D = round(min(0.5, 0.1 + 0.02 * h_len) + random.uniform(0, 0.05), 3)
-
+    phi_C = 0.8
+    D = min(0.5, 0.1 + 0.02 * h_len)
     return {"q": q, "s": s, "t": t, "phi_C": phi_C, "D": D}
 
 
-def hybrid_por_score(params: Dict[str, Any], question: str, history: List["QaRecord"], w1: float = 0.6, w2: float = 0.4) -> float:
-    """Return a hybrid PoR score using UGHer and semantic similarity."""
+def hybrid_por_score(
+    params: Dict[str, Any], question: str, history: List["QaRecord"], *, w1: float = 0.6, w2: float = 0.4
+) -> float:
+    """Return PoR score based on UGHer model and semantic similarity."""
     trig = por_trigger(params["q"], params["s"], params["t"], params["phi_C"], params["D"])
-    por1 = trig["score"] * (1 - params["D"])
-
+    por_model = trig["score"] * (1 - params["D"])
     if history:
-        max_sim = max(compute_semantic_similarity(question, h.question) for h in history)
-        por2 = 1.0 - max_sim
+        max_sim = max(_similarity(question, h.question) for h in history)
+        por_sim = 1.0 - max_sim
     else:
-        por2 = 1.0
-
-    score = w1 * por1 + w2 * por2
-    return round(score, 2)
+        por_sim = 1.0
+    return round(w1 * por_model + w2 * por_sim, 3)
 
 
-def deltae_score(prev_answer: str | None, curr_answer: str) -> float:
-    """Compute ΔE between two answers based on textual difference."""
+def delta_e(prev_answer: str | None, curr_answer: str) -> float:
+    """Return ΔE based on semantic difference between answers."""
     if prev_answer is None:
         return 0.0
-    diff = 1.0 - compute_semantic_similarity(prev_answer, curr_answer)
-    return round(diff, 3)
+    return round(1.0 - _similarity(prev_answer, curr_answer), 3)
 
 
 def grv_score(answer: str) -> float:
-    """Wrapper around :func:`grv_scoring.grv_score`."""
+    """Proxy to :func:`grv_scoring.grv_score`."""
     return grv_scoring.grv_score(answer)
 
 
-def evaluate_metrics(por: float, delta_e: float, grv: float) -> Tuple[float, bool]:
-    """Return combined score and adoption flag based on weights and threshold."""
-    score = W_POR * por + W_DE * (1 - delta_e) + W_GRV * grv
+def evaluate_metrics(por: float, delta_e_val: float, grv: float) -> Tuple[float, bool]:
+    """Return overall score and adoption flag."""
+    score = W_POR * por + W_DE * (1 - delta_e_val) + W_GRV * grv
     return round(score, 3), score >= ADOPT_TH
 
 
 # ---------------------------------------------------------------------------
-# record structure
+# Data model
 # ---------------------------------------------------------------------------
 
 @dataclass
@@ -101,35 +112,34 @@ class QaRecord:
 
 
 # ---------------------------------------------------------------------------
-# cycle logic
+# Cycle logic
 # ---------------------------------------------------------------------------
 
-def run_cycle(steps: int, output: Path, interactive: bool = False) -> None:
-    """Run a Q&A cycle and persist metrics to ``output`` CSV."""
+def run_cycle(steps: int, output: Path, *, interactive: bool = False) -> None:
+    """Run the Q&A cycle for ``steps`` iterations and store results to ``output``."""
     history: List[QaRecord] = []
     prev_answer: str | None = None
 
-    for step in range(steps):
+    for idx in range(steps):
         if interactive:
-            question = input(f"質問{step + 1}: ")
+            question = input(f"質問{idx + 1}: ")
         else:
-            question = f"Q{step + 1}"
+            question = f"Q{idx + 1}"
 
         answer = get_ai_response(question)
         params = estimate_ugh_params(question, history)
         por = hybrid_por_score(params, question, history)
-        delta_e = deltae_score(prev_answer, answer)
+        de = delta_e(prev_answer, answer)
         grv = grv_score(answer)
 
         print(f"[AI応答] {answer}")
-        print(f"【PoR】{por:.2f} | 【ΔE】{delta_e:.3f} | 【grv】{grv:.3f}")
-
-        score, adopted = evaluate_metrics(por, delta_e, grv)
-        label = "採用" if adopted else "不採用"
-        print(f"【総合】{score:.3f} → {label}")
+        print(f"【PoR】{por:.2f} | 【ΔE】{de:.3f} | 【grv】{grv:.3f}")
+        score, adopted = evaluate_metrics(por, de, grv)
+        decision = "採用" if adopted else "不採用"
+        print(f"【総合】{score:.3f} → {decision}")
 
         if adopted:
-            history.append(QaRecord(question, answer, por, delta_e, grv))
+            history.append(QaRecord(question, answer, por, de, grv))
         prev_answer = answer
 
     if history:
@@ -141,13 +151,16 @@ def run_cycle(steps: int, output: Path, interactive: bool = False) -> None:
 
 
 # ---------------------------------------------------------------------------
-# CLI
+# CLI entry point
 # ---------------------------------------------------------------------------
 
-def main(argv: list[str] | None = None) -> None:
+def main(argv: List[str] | None = None) -> None:
+    """Command line interface for the collector."""
     parser = argparse.ArgumentParser(description="PoR/ΔE/grv collector")
     parser.add_argument("-n", "--steps", type=int, default=10, help="number of cycles")
-    parser.add_argument("-o", "--output", type=Path, default=Path("por_history.csv"), help="CSV output path")
+    parser.add_argument(
+        "-o", "--output", type=Path, default=Path("por_history.csv"), help="CSV output path"
+    )
     parser.add_argument("--auto", action="store_true", help="run without interactive prompts")
     args = parser.parse_args(argv)
 


### PR DESCRIPTION
## Summary
- rewrite `por_deltae_grv_collector.py` as an integrated Q&A logger
- compute PoR from UGHer parameters and semantic similarity
- calculate ΔE from consecutive answers
- evaluate history adoption using weighted PoR/ΔE/grv score

## Testing
- `python -m pytest -q` *(fails: No module named pytest)*