### PR TITLE
Add mypy type checking

### DIFF
--- a/.github/workflows/typecheck.yml
+++ b/.github/workflows/typecheck.yml
@@ -1,0 +1,19 @@
+name: Mypy Type Check
+
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+    branches: [ main ]
+
+jobs:
+  mypy:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+      - run: pip install -r requirements.txt
+      - run: pip install mypy
+      - run: mypy .

--- a/examples/phase_map_heatmap.py
+++ b/examples/phase_map_heatmap.py
@@ -64,7 +64,7 @@ def plot_heatmap(history: List[PorRecord]) -> None:
         aspect="auto",
         cmap="viridis",
         origin="lower",
-        extent=[0, len(por_values), 0.0, 1.0],
+        extent=(0.0, float(len(por_values)), 0.0, 1.0),
     )
     plt.xlabel("Phase")
     plt.ylabel("PoR score")

--- a/mypy.ini
+++ b/mypy.ini
@@ -1,0 +1,5 @@
+[mypy]
+python_version = 3.11
+files = .
+strict = True
+ignore_missing_imports = True

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,3 +2,4 @@ matplotlib
 pytest
 pandas
 seaborn
+mypy


### PR DESCRIPTION
## Summary
- add `mypy.ini` with strict settings
- install mypy in requirements
- check types on GitHub Actions using Python 3.11
- ensure `extent` for imshow is a tuple

## Testing
- `python -m mypy .`
- `python -m pytest -q` *(fails: No module named pytest)*