### PR TITLE
Fix load_config typing

### DIFF
--- a/utils/config_loader.py
+++ b/utils/config_loader.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import json
 from pathlib import Path
-from typing import Any, Dict
+from typing import Any, Dict, cast
 
 CONFIG_PATH = Path(__file__).resolve().parent.parent / "config.json"
 
@@ -10,7 +10,8 @@ CONFIG_PATH = Path(__file__).resolve().parent.parent / "config.json"
 def load_config(path: Path = CONFIG_PATH) -> Dict[str, Any]:
     """Load configuration parameters from a JSON file."""
     with open(path, "r", encoding="utf-8") as fh:
-        return json.load(fh)
+        config_data = json.load(fh)
+    return cast(Dict[str, Any], config_data)
 
 
 CONFIG: Dict[str, Any] = load_config()


### PR DESCRIPTION
## Summary
- ensure `load_config` returns `Dict[str, Any]`
- cast the result of `json.load` for clarity

## Testing
- `python -m pytest -q`
- `python -m mypy --show-error-codes utils/config_loader.py`
