### PR TITLE
Define typed return for por_trigger

### DIFF
--- a/design_sketch.py
+++ b/design_sketch.py
@@ -1,7 +1,17 @@
 from __future__ import annotations
 
+from typing import TypedDict
 
-def por_trigger(q: float, s: float, t: float, phi_C: float, D: float, *, theta: float = 0.6) -> dict:
+
+class PorTriggerResult(TypedDict):
+    """Return type for :func:`por_trigger`."""
+
+    E_prime: float
+    score: float
+    triggered: bool
+
+
+def por_trigger(q: float, s: float, t: float, phi_C: float, D: float, *, theta: float = 0.6) -> PorTriggerResult:
     """Return PoR trigger metrics for the given parameters."""
     # Compute the intermediate energy metric
     E_prime = q * s * t

--- a/facade/trigger.py
+++ b/facade/trigger.py
@@ -7,11 +7,21 @@ based on the descriptions provided in design_sketch.py and spec.md.
 
 from __future__ import annotations
 
+from typing import TypedDict
+
 from secl.qa_cycle import main_qa_cycle
 
 
+class PorTriggerResult(TypedDict):
+    """Return type for :func:`por_trigger`."""
 
-def por_trigger(q: float, s: float, t: float, phi_C: float, D: float, *, theta: float = 0.6) -> dict:
+    E_prime: float
+    score: float
+    triggered: bool
+
+
+
+def por_trigger(q: float, s: float, t: float, phi_C: float, D: float, *, theta: float = 0.6) -> PorTriggerResult:
     """Calculate whether a PoR event should be triggered.
 
     Parameters
@@ -31,7 +41,7 @@ def por_trigger(q: float, s: float, t: float, phi_C: float, D: float, *, theta: 
 
     Returns
     -------
-    dict
+    PorTriggerResult
         Dictionary containing ``"E_prime"``, ``"score"``, and ``"triggered"``
         keys representing intermediate values and the final boolean result.
     """


### PR DESCRIPTION
## Summary
- create `PorTriggerResult` TypedDict
- use the new return type for `por_trigger`

## Testing
- `python -m mypy design_sketch.py facade/trigger.py --follow-imports=skip`
- `python -m pytest -q`