### PR TITLE
AUTO: fix until tests pass

### DIFF
--- a/secl/qa_cycle.py
+++ b/secl/qa_cycle.py
@@ -136,18 +136,20 @@ def update_score_threshold(delta_e_history: List[float], base_threshold: float =
 
 
 def simulate_grv_gain_with_jump(current_state: Dict[str, Any], base: str = "ジャンプ") -> float:
+    current_grv = float(current_state["grv"])
     base_vocab = set(current_state["vocab_set"])
     added = {base + str(random.randint(100,999))}
     simulated = base_vocab | added
-    gain = min(1.0, len(simulated)/30.0) - current_state["grv"]
+    gain = min(1.0, len(simulated)/30.0) - current_grv
     return gain
 
 
 def simulate_grv_gain_with_external_info(current_state: Dict[str, Any]) -> float:
+    current_grv = float(current_state["grv"])
     base_vocab = set(current_state["vocab_set"])
     added = {simulate_external_knowledge()}
     simulated = base_vocab | added
-    gain = min(1.0, len(simulated)/30.0) - current_state["grv"]
+    gain = min(1.0, len(simulated)/30.0) - current_grv
     return gain
 
 
@@ -319,6 +321,7 @@ def main_qa_cycle(n_steps: int = 25, save_path: Path | None = None) -> List[Hist
     grv_history: List[float] = []
     score_threshold = BASE_SCORE_THRESHOLD
     current_question = "意識はどこから生まれるか？"
+    prev_question: str = current_question
     for step in range(n_steps):
         print(f"\n--- Step {step+1} ---")
         answer = simulate_generate_answer(current_question)

--- a/tests/test_grv_gain.py
+++ b/tests/test_grv_gain.py
@@ -1,0 +1,16 @@
+import sys, os
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
+
+import unittest
+from secl.qa_cycle import simulate_grv_gain_with_jump, simulate_grv_gain_with_external_info
+
+class TestGrvGain(unittest.TestCase):
+    def test_gain_returns_float(self):
+        state = {"vocab_set": {"a", "b"}, "grv": 0.2}
+        gain_jump = simulate_grv_gain_with_jump(state)
+        gain_ext = simulate_grv_gain_with_external_info(state)
+        self.assertIsInstance(gain_jump, float)
+        self.assertIsInstance(gain_ext, float)
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
## Summary
- cast current_state['grv'] to float before using in gain calculation
- keep prev_question typed to satisfy mypy
- add tests for grv gain functions

## Testing
- `pytest -q`
- `mypy secl/qa_cycle.py`