### PR TITLE
Add explicit return types to tests

### DIFF
--- a/tests/test_anomalies.py
+++ b/tests/test_anomalies.py
@@ -12,18 +12,18 @@ from secl.qa_cycle import (
 import json
 
 class TestAnomalies(unittest.TestCase):
-    def test_check_metric_anomalies(self):
+    def test_check_metric_anomalies(self) -> None:
         por, de, grv = check_metric_anomalies(0.95, 0.95, 0.96)
         self.assertTrue(por)
         self.assertTrue(de)
         self.assertTrue(grv)
 
-    def test_detect_por_null(self):
+    def test_detect_por_null(self) -> None:
         self.assertTrue(detect_por_null('', 'ans', 0, 0))
         self.assertTrue(detect_por_null('q', '', 0, 0))
         self.assertFalse(detect_por_null('q', 'ans', 1.0, 0.5))
 
-    def test_backup_history(self):
+    def test_backup_history(self) -> None:
         hist = [HistoryEntry('q', 'a', 0.1, 0.2, 0.3, False, False)]
         tmp_dir = Path('tests/tmp_bk')
         backup_history(tmp_dir, hist, 'test')

--- a/tests/test_examples.py
+++ b/tests/test_examples.py
@@ -1,14 +1,14 @@
 import matplotlib
 matplotlib.use('Agg')
 
-def test_import_example_modules():
+def test_import_example_modules() -> None:
     import phase_map_demo
     import facade.collector
     import secl.qa_cycle
     import core.history
 
 
-def test_scripts_run(tmp_path):
+def test_scripts_run(tmp_path) -> None:
     import phase_map_demo
     import facade.collector
     import secl.qa_cycle
@@ -29,7 +29,7 @@ def test_scripts_run(tmp_path):
     secl.qa_cycle.main_qa_cycle(1, tmp_path / "hist.csv")
 
 
-def test_run_cycle_generates_csv(tmp_path):
+def test_run_cycle_generates_csv(tmp_path) -> None:
     """run_cycle should create a CSV with expected columns and rows."""
     from facade.collector import run_cycle
     out_file = tmp_path / "cycle.csv"

--- a/tests/test_metrics.py
+++ b/tests/test_metrics.py
@@ -7,15 +7,15 @@ from secl.qa_cycle import novelty_score, is_duplicate_question, HistoryEntry
 
 
 class TestMetrics(unittest.TestCase):
-    def test_novelty_empty_history(self):
+    def test_novelty_empty_history(self) -> None:
         self.assertEqual(novelty_score('q', []), 1.0)
 
-    def test_novelty_similarity_penalty(self):
+    def test_novelty_similarity_penalty(self) -> None:
         history = [HistoryEntry('hello world', 'ans', 0, 0, 0, False, False)]
         result = novelty_score('hello world', history)
         self.assertLess(result, 1.0)
 
-    def test_duplicate_detection(self):
+    def test_duplicate_detection(self) -> None:
         history = [HistoryEntry('what is life?', 'ans', 0, 0, 0, False, False)]
         self.assertTrue(is_duplicate_question('what is life?', history))
         self.assertFalse(is_duplicate_question('another', history))

--- a/tests/test_smoke.py
+++ b/tests/test_smoke.py
@@ -1,7 +1,7 @@
 import sys, os
 sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
 
-def test_imports():
+def test_imports() -> None:
     import facade.trigger
     import core.deltae
     import core.grv


### PR DESCRIPTION
## Summary
- annotate all test functions with `-> None`
- run `mypy` to confirm no untyped definitions remain

## Testing
- `mypy tests`
- `python -m pytest -q`