### PR TITLE
Fix matplotlib extent typing

### DIFF
--- a/examples/phase_map_heatmap.py
+++ b/examples/phase_map_heatmap.py
@@ -64,7 +64,7 @@ def plot_heatmap(history: List[PorRecord]) -> None:
         aspect="auto",
         cmap="viridis",
         origin="lower",
-        extent=[0, len(por_values), 0.0, 1.0],
+        extent=(0, len(por_values), 0.0, 1.0),
     )
     plt.xlabel("Phase")
     plt.ylabel("PoR score")


### PR DESCRIPTION
## Summary
- switch extent to a tuple in `examples/phase_map_heatmap.py`

## Testing
- `pytest -q`
- `mypy examples/phase_map_heatmap.py` *(fails: Library stubs not installed for "pandas")*