### PR TITLE
Add shared PorTriggerResult TypedDict and update imports

### DIFF
--- a/design_sketch.py
+++ b/design_sketch.py
@@ -1,15 +1,6 @@
 from __future__ import annotations
 
-from typing import TypedDict
-
-
-class PorTriggerResult(TypedDict):
-    """Return type for :func:`por_trigger`."""
-
-    E_prime: float
-    score: float
-    triggered: bool
-
+from utils.typing import PorTriggerResult
 
 def por_trigger(q: float, s: float, t: float, phi_C: float, D: float, *, theta: float = 0.6) -> PorTriggerResult:
     """Return PoR trigger metrics for the given parameters."""

--- a/facade/trigger.py
+++ b/facade/trigger.py
@@ -6,20 +6,8 @@ based on the descriptions provided in design_sketch.py and spec.md.
 """
 
 from __future__ import annotations
-
-from typing import TypedDict
-
+from utils.typing import PorTriggerResult
 from secl.qa_cycle import main_qa_cycle
-
-
-class PorTriggerResult(TypedDict):
-    """Return type for :func:`por_trigger`."""
-
-    E_prime: float
-    score: float
-    triggered: bool
-
-
 
 def por_trigger(q: float, s: float, t: float, phi_C: float, D: float, *, theta: float = 0.6) -> PorTriggerResult:
     """Calculate whether a PoR event should be triggered.

--- a/utils/typing.py
+++ b/utils/typing.py
@@ -1,0 +1,14 @@
+from __future__ import annotations
+
+from typing import TypedDict
+
+
+class PorTriggerResult(TypedDict):
+    """Return type for :func:`por_trigger`."""
+
+    E_prime: float
+    score: float
+    triggered: bool
+
+
+__all__ = ["PorTriggerResult"]


### PR DESCRIPTION
## Summary
- define `PorTriggerResult` in `utils/typing.py`
- use the shared `PorTriggerResult` in `design_sketch.py` and `facade/trigger.py`

## Testing
- `pytest -q`
- `mypy design_sketch.py facade/trigger.py`
