### PR TITLE
Add PorTriggerResult TypedDict in design sketch

### DIFF
--- a/design_sketch.py
+++ b/design_sketch.py
@@ -1,6 +1,14 @@
 from __future__ import annotations
 
-from utils.typing import PorTriggerResult
+from typing import TypedDict
+
+
+class PorTriggerResult(TypedDict):
+    """Return type for :func:`por_trigger`."""
+
+    E_prime: float
+    score: float
+    triggered: bool
 
 def por_trigger(q: float, s: float, t: float, phi_C: float, D: float, *, theta: float = 0.6) -> PorTriggerResult:
     """Return PoR trigger metrics for the given parameters."""

--- a/facade/trigger.py
+++ b/facade/trigger.py
@@ -6,7 +6,7 @@ based on the descriptions provided in design_sketch.py and spec.md.
 """
 
 from __future__ import annotations
-from utils.typing import PorTriggerResult
+from design_sketch import PorTriggerResult
 from secl.qa_cycle import main_qa_cycle
 
 def por_trigger(q: float, s: float, t: float, phi_C: float, D: float, *, theta: float = 0.6) -> PorTriggerResult:


### PR DESCRIPTION
## Summary
- add `PorTriggerResult` TypedDict definition in `design_sketch.py`
- reference the new TypedDict from `facade.trigger`

## Testing
- `python -m pytest -q`