### PR TITLE
Add multi-provider AI response helper

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -3,3 +3,7 @@ pytest
 pandas
 seaborn
 mypy
+# Optional libraries for AI providers
+# openai - required for OpenAI API
+# anthropic - required for Anthropic API
+# google-generativeai - required for Google Gemini API


### PR DESCRIPTION
## Summary
- add environment configurable AI provider in `get_ai_response`
- implement wrappers for OpenAI, Anthropic and Google Gemini with safe fallbacks
- document optional AI libraries in requirements

## Testing
- `pytest -q`