### PR TITLE
Add multi-provider AI response helper

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -3,3 +3,7 @@ pytest
 pandas
 seaborn
 mypy
+# Optional AI provider libraries (uncomment to enable)
+# openai
+# anthropic
+# google-generativeai


### PR DESCRIPTION
## Summary
- add multi-provider AI response helper
- implement wrappers for OpenAI, Anthropic and Google Gemini with safe fallbacks
- document optional AI libraries in requirements

## Testing
- `pytest -q`
- `mypy .`
