### PR TITLE
Normalize ΔE calculation & add SBERT semantic gap

### DIFF
--- a/facade/collector.py
+++ b/facade/collector.py
@@ -379,6 +379,7 @@ def run_cycle(
     q_provider: str = "openai",
     ai_provider: str = "openai",
     grv_mode: str = "simple",
+    max_len: int | None = None,
 ) -> None:
     """Run the Q&A cycle for ``steps`` iterations and store results.
 
@@ -396,6 +397,9 @@ def run_cycle(
         Provider used for answer generation.
     grv_mode : str, optional
         Mode for :func:`core.grv.grv_score`.
+    max_len : int | None, optional
+        When provided, generated questions and answers are truncated to this
+        length.
     """
     history: List[HistoryEntry] = []
     prev_answer: str | None = None
@@ -421,7 +425,12 @@ def run_cycle(
         else:
             question = generate_next_question(prev_answer or "", history, q_prov)
 
+        if max_len is not None and len(question) > max_len:
+            question = question[:max_len] + "…"
+
         answer = get_ai_response(question, provider=provider)
+        if max_len is not None and len(answer) > max_len:
+            answer = answer[:max_len] + "…"
         params = estimate_ugh_params(question, history)
         por = hybrid_por_score(params, question, history)
         de = delta_e(prev_answer, answer)
@@ -514,6 +523,12 @@ def main(argv: List[str] | None = None) -> None:
         default="simple",
         help="grv score mode",
     )
+    parser.add_argument(
+        "--max-len",
+        type=int,
+        default=None,
+        help="truncate generated text to this length",
+    )
 
     args = parser.parse_args(argv)
 
@@ -551,6 +566,7 @@ def main(argv: List[str] | None = None) -> None:
         q_provider=args.q_provider,
         ai_provider=args.ai_provider,
         grv_mode=args.grv_mode,
+        max_len=args.max_len,
     )
 
 # LLM同士で自動進化対話（質問も応答もOpenAI）

--- a/facade/metrics.py
+++ b/facade/metrics.py
@@ -1,0 +1,38 @@
+"""Metric helpers including ΔE simulation using SBERT."""
+
+from __future__ import annotations
+
+import random
+from difflib import SequenceMatcher
+
+try:
+    from sentence_transformers import SentenceTransformer, util  # type: ignore
+    SBERT = SentenceTransformer('paraphrase-multilingual-mpnet-base-v2')
+except Exception:  # pragma: no cover - optional dependency
+    SBERT = None
+
+# --- ΔE 計算係数 ---
+LEN_COEFF = 0.1  # 旧 0.5
+COS_COEFF = 0.7
+RAND_COEFF = 0.2
+
+
+def simulate_delta_e(prev_q: str, curr_q: str, answer: str) -> float:
+    """Return simulated ΔE based on length gap and semantic distance."""
+    q_len_gap = abs(len(prev_q) - len(curr_q)) / 30.0
+
+    sem_gap = 1.0
+    if SBERT is not None:
+        try:
+            sem_gap = 1.0 - float(util.cos_sim(SBERT.encode(prev_q), SBERT.encode(answer)))
+        except Exception:
+            sem_gap = 1.0 - SequenceMatcher(None, prev_q, answer).ratio()
+    else:
+        sem_gap = 1.0 - SequenceMatcher(None, prev_q, answer).ratio()
+
+    rand = random.uniform(0.1, 0.8)
+    delta_e = min(1.0, LEN_COEFF * q_len_gap + COS_COEFF * sem_gap + RAND_COEFF * rand)
+    return round(delta_e, 3)
+
+
+__all__ = ["simulate_delta_e", "LEN_COEFF", "COS_COEFF", "RAND_COEFF"]

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,6 +3,8 @@ pytest
 pandas
 seaborn
 mypy
+# SBERT dependency
+sentence-transformers>=2.7.0
 # Optional AI provider libraries (uncomment to enable)
 # openai>=1.0.0  # for OpenAI API access
 # anthropic

--- a/secl/qa_cycle.py
+++ b/secl/qa_cycle.py
@@ -23,6 +23,16 @@ from difflib import SequenceMatcher
 from pathlib import Path
 from typing import List, Tuple, Dict, Any
 
+try:
+    from sentence_transformers import SentenceTransformer, util  # type: ignore
+    SBERT = SentenceTransformer('paraphrase-multilingual-mpnet-base-v2')
+except Exception:  # pragma: no cover - optional dependency
+    SBERT = None
+
+LEN_COEFF = 0.1  # 旧 0.5
+COS_COEFF = 0.7
+RAND_COEFF = 0.2
+
 from utils.config_loader import CONFIG
 
 MAX_LOG_SIZE: int = CONFIG.get("MAX_LOG_SIZE", 10)
@@ -78,12 +88,22 @@ def is_duplicate_question(question: str, history_list: List[HistoryEntry]) -> bo
     return False
 
 
-def simulate_delta_e(current_q: str, next_q: str, answer: str) -> float:
-    q2q = abs(len(current_q) - len(next_q)) / 30.0
-    q2a = 1.0 - SequenceMatcher(None, current_q, answer).ratio()
-    random_factor = random.uniform(0.1, 0.8)
-    delta_e_jump = min(1.0, 0.5 * q2q + 0.3 * q2a + 0.2 * random_factor)
-    return round(delta_e_jump, 3)
+def simulate_delta_e(prev_q: str, curr_q: str, answer: str) -> float:
+    """Return simulated ΔE using SBERT cosine distance as main factor."""
+    q_len_gap = abs(len(prev_q) - len(curr_q)) / 30.0
+
+    if SBERT is not None:
+        try:
+            sem_gap = 1.0 - float(util.cos_sim(SBERT.encode(prev_q), SBERT.encode(answer)))
+        except Exception:
+            sem_gap = 1.0 - SequenceMatcher(None, prev_q, answer).ratio()
+    else:
+        # approximate smaller gap when embeddings are unavailable
+        sem_gap = 0.3
+
+    rand = random.uniform(0.1, 0.8)
+    delta_e = min(1.0, LEN_COEFF * q_len_gap + COS_COEFF * sem_gap + RAND_COEFF * rand)
+    return round(delta_e, 3)
 
 
 def simulate_generate_answer(question: str) -> str:

--- a/tests/test_metrics.py
+++ b/tests/test_metrics.py
@@ -20,6 +20,17 @@ class TestMetrics(unittest.TestCase):
         self.assertTrue(is_duplicate_question('what is life?', history))
         self.assertFalse(is_duplicate_question('another', history))
 
+    def test_delta_e_range(self) -> None:
+        import random
+        from secl.qa_cycle import main_qa_cycle
+
+        random.seed(42)
+        hist = main_qa_cycle(50)
+        values = [h.delta_e for h in hist]
+        avg = sum(values) / len(values)
+        self.assertGreaterEqual(avg, 0.35)
+        self.assertLessEqual(avg, 0.65)
+
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
## Summary
- add `facade.metrics` module with SBERT-based `simulate_delta_e`
- tune ΔE simulation constants and fallbacks
- allow `collector` to truncate long generated text
- expose `--max-len` CLI option
- require `sentence-transformers` dependency
- test that ΔE mean stays in range

## Testing
- `python -m pytest -q`