### PR TITLE
Fix SBERT typing and cleanup imports

### DIFF
--- a/facade/collector.py
+++ b/facade/collector.py
@@ -38,7 +38,7 @@ def get_sbert() -> SentenceTransformer:
     global _ST_MODEL
     if _ST_MODEL is None:
         _ST_MODEL = SentenceTransformer(SBERT_MODEL_ID)
-    return cast(SentenceTransformer, _ST_MODEL)
+    return _ST_MODEL
 
 from utils.config_loader import MAX_VOCAB_CAP
 
@@ -245,7 +245,6 @@ def generate_next_question(
 ) -> str:
     """Return the next question using the specified LLM provider."""
     if provider == "template":
-        from typing import cast
         from secl.qa_cycle import (
             simulate_generate_next_question_from_answer,
             HistoryEntry as SeHistoryEntry,

--- a/facade/metrics.py
+++ b/facade/metrics.py
@@ -22,7 +22,7 @@ def get_sbert() -> SentenceTransformer:
     global _ST_MODEL
     if _ST_MODEL is None:
         _ST_MODEL = SentenceTransformer(SBERT_MODEL_ID)
-    return cast(SentenceTransformer, _ST_MODEL)
+    return _ST_MODEL
 
 # --- ΔE 計算係数 ---
 LEN_COEFF = 0.1  # 旧 0.5

--- a/secl/qa_cycle.py
+++ b/secl/qa_cycle.py
@@ -39,7 +39,7 @@ def get_sbert() -> SentenceTransformer:
     global _ST_MODEL
     if _ST_MODEL is None:
         _ST_MODEL = SentenceTransformer(SBERT_MODEL_ID)
-    return cast(SentenceTransformer, _ST_MODEL)
+    return _ST_MODEL
 
 LEN_COEFF = 0.1  # 旧 0.5
 COS_COEFF = 0.7


### PR DESCRIPTION
## Summary
- type SBERT singleton as `Optional[SentenceTransformer]` across modules
- return the cached instance directly without casts
- drop redundant `cast` import inside `generate_next_question`

## Testing
- `pytest -q`
- `mypy . --show-error-codes`
