### PR TITLE
Add strict CI guard

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,26 +7,22 @@ on:
     branches: [ main ]
 
 jobs:
-  test:
+  build:
     runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-python@v5
         with:
-          python-version: "3.12"
-      - run: pip install -v -r requirements.txt
-      - name: Sanity-check deps
+          python-version: "3.11"
+      - name: Install dependencies
         run: |
-          test -f requirements.txt || { echo "❌ requirements.txt not found"; exit 1; }
-          python - <<'PY'
-          import importlib, sys
-          for pkg in ("matplotlib", "pytest"):
-              try:
-                  m = importlib.import_module(pkg)
-                  print(f"[OK] {pkg} {m.__version__}")
-              except ModuleNotFoundError:
-                  print(f"❌  {pkg} NOT INSTALLED")
-                  sys.exit(1)
-          PY
-      - run: python -c "import matplotlib"
-      - run: pytest -q
+          pip install -r requirements.txt
+          pip install pre-commit mypy
+      - name: Run pre-commit
+        run: pre-commit run --all-files --show-diff-on-failure --color always
+      - name: Run pytest
+        run: pytest -q
+      - name: Run mypy
+        run: mypy

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,17 @@
+repos:
+  - repo: https://github.com/psf/black
+    rev: 23.9.1
+    hooks:
+      - id: black
+
+  - repo: https://github.com/astral-sh/ruff-pre-commit
+    rev: v0.1.5
+    hooks:
+      - id: ruff
+        args: ["--fix"]
+
+  - repo: https://github.com/pre-commit/mirrors-mypy
+    rev: v1.8.0
+    hooks:
+      - id: mypy
+        args: ["--strict"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,3 +13,15 @@ build-backend = "setuptools.build_meta"
 
 [project.optional-dependencies]
 dev = ["sentence-transformers>=0.12.0"]
+
+[tool.mypy]
+strict = true
+warn_unused_ignores = true
+disallow_any_generics = true
+disallow_any_untyped_defs = true
+no_implicit_optional = true
+
+[tool.ruff]
+line-length = 100
+extend-select = ["PGH"]
+extend-ignore = ["ANN101"]

--- a/tests/test_placeholder.py
+++ b/tests/test_placeholder.py
@@ -1,0 +1,2 @@
+def test_remove_me() -> None:
+    assert False, "このテストが残っている限り CI は通りません"


### PR DESCRIPTION
## Summary
- create `.pre-commit-config.yaml` with black, ruff, and mypy hooks (mypy runs in `--strict` mode; ruff fixes issues automatically)
- strengthen mypy and ruff config in `pyproject.toml`
- replace CI workflow to run pre-commit, pytest, then mypy on Python 3.11
- add failing placeholder test

## Testing
- `black tests/test_placeholder.py`
- `ruff check --fix tests/test_placeholder.py`
- `mypy`
- `python -m pytest -q` *(fails: `tests/test_placeholder.py::test_remove_me`)*