### PR TITLE
Set up strict CI with placeholder test

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,31 +2,27 @@ name: CI
 
 on:
   push:
-    branches: [ main ]
+    branches: [main]
   pull_request:
-    branches: [ main ]
+    branches: [main]
 
 jobs:
-  test:
+  build:
     runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-python@v5
         with:
-          python-version: "3.12"
-      - run: pip install -v -r requirements.txt
-      - name: Sanity-check deps
+          python-version: '3.11'
+      - name: Install
         run: |
-          test -f requirements.txt || { echo "❌ requirements.txt not found"; exit 1; }
-          python - <<'PY'
-          import importlib, sys
-          for pkg in ("matplotlib", "pytest"):
-              try:
-                  m = importlib.import_module(pkg)
-                  print(f"[OK] {pkg} {m.__version__}")
-              except ModuleNotFoundError:
-                  print(f"❌  {pkg} NOT INSTALLED")
-                  sys.exit(1)
-          PY
-      - run: python -c "import matplotlib"
-      - run: pytest -q
+          pip install -r requirements.txt
+          pip install pre-commit
+      - name: Run pre-commit
+        run: pre-commit run --all-files --show-diff-on-failure
+      - name: Run pytest
+        run: pytest -q
+      - name: Run mypy
+        run: mypy --strict

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,15 @@
+repos:
+  - repo: https://github.com/psf/black
+    rev: 23.12.1
+    hooks:
+      - id: black
+  - repo: https://github.com/astral-sh/ruff-pre-commit
+    rev: v0.3.7
+    hooks:
+      - id: ruff
+        args: ["--fix"]
+  - repo: https://github.com/pre-commit/mirrors-mypy
+    rev: v1.10.0
+    hooks:
+      - id: mypy
+        args: ["--strict"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,3 +13,16 @@ build-backend = "setuptools.build_meta"
 
 [project.optional-dependencies]
 dev = ["sentence-transformers>=0.12.0"]
+
+[tool.mypy]
+python_version = "3.11"
+strict = true
+warn_unused_ignores = true
+disallow_any_generics = true
+disallow_any_untyped_defs = true
+no_implicit_optional = true
+
+[tool.ruff]
+line-length = 100
+extend-select = ["PGH"]
+extend-ignore = ["ANN101"]

--- a/tests/test_placeholder.py
+++ b/tests/test_placeholder.py
@@ -1,0 +1,2 @@
+def test_remove_me():
+    assert False, "このテストが残っている限り CI は通りません"


### PR DESCRIPTION
## Summary
- configure mypy and ruff in `pyproject.toml`
- add pre-commit hooks for black, ruff and mypy
- define GitHub Actions workflow running pre-commit, tests and mypy
- add failing placeholder test

## Testing
- `ruff check .` *(fails: E402, PGH003 and others)*
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'matplotlib')*
- `mypy --strict` *(fails: found 11 errors)*
