### PR TITLE
Update README with ΔE v2 install instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,16 @@ pip install git+https://github.com/Yuu6798/ugh3-metrics-lib.git
 git clone https://github.com/Yuu6798/ugh3-metrics-lib.git
 ```
 
+## Installation (v2)
+```bash
+pip install -r requirements.txt
+```
+
+## Recalculate historical ΔE
+```bash
+python recalc_deltae.py --input runs/deltae_log.csv --output runs/deltae_v2.csv
+```
+
 ## Quick Start / クイックスタート
 ```python
 from facade.trigger import por_trigger


### PR DESCRIPTION
## Summary
- add new installation instructions for ΔE v2
- show one-liner for recalculating historical ΔE values

## Testing
- `pytest -q`