### PR TITLE
Add caching to CI workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,6 +14,25 @@ jobs:
       - uses: actions/setup-python@v5
         with:
           python-version: "3.12"
+      #––– Cache pip wheels –––#
+      - name: Cache pip wheels
+        uses: actions/cache@v4
+        with:
+          path: ~/.cache/pip
+          key: >
+            pip-${{ runner.os }}-${{ hashFiles('requirements.txt') }}
+          restore-keys: |
+            pip-${{ runner.os }}-
+
+      #––– Cache HuggingFace models –––#
+      - name: Cache HuggingFace models
+        uses: actions/cache@v4
+        with:
+          path: ~/.cache/huggingface
+          key: >
+            hf-${{ runner.os }}-${{ hashFiles('requirements.txt') }}
+          restore-keys: |
+            hf-${{ runner.os }}-
       - run: pip install -v -r requirements.txt
       - name: Sanity-check deps
         run: |


### PR DESCRIPTION
## Summary
- cache pip wheels before installing dependencies in CI
- cache HuggingFace models to speed up tests

## Testing
- `pytest -q`