### PR TITLE
Update mypy settings

### DIFF
--- a/mypy.ini
+++ b/mypy.ini
@@ -1,4 +1,16 @@
 [mypy]
-strict = True
+python_version = 3.11
 plugins = pydantic.mypy
 files = .
+color_output = True
+show_error_codes = True
+warn_unused_ignores = True
+
+[mypy-src.*]
+strict = True
+
+[mypy-scripts.*]
+ignore_missing_imports = True
+warn_return_any = False
+disallow_untyped_defs = False
+disallow_incomplete_defs = False


### PR DESCRIPTION
## Summary
- configure `mypy` for Python 3.11 and pydantic plugin
- enable colored output and error codes
- warn on unused `# type: ignore`
- enforce strict checking for `src`
- loosen settings for `scripts`

## Testing
- `pytest -q`