### PR TITLE
Restore mypy config and CI install step

### DIFF
--- a/mypy.ini
+++ b/mypy.ini
@@ -2,8 +2,8 @@
 python_version = 3.11
 plugins = pydantic.mypy
 files = .
-color_output = True
 show_error_codes = True
+pretty = True
 warn_unused_ignores = True
 
 [mypy-src.*]
@@ -14,3 +14,6 @@ ignore_missing_imports = True
 warn_return_any = False
 disallow_untyped_defs = False
 disallow_incomplete_defs = False
+
+[mypy-openai.*]
+ignore_missing_imports = True


### PR DESCRIPTION
## Summary
- remove `types-openai` from CI dependency installation
- restore correct `mypy.ini` and ignore missing imports for `openai`

## Testing
- `python -m pytest -q`