### PR TITLE
Cleanup unused type: ignore comments

### DIFF
--- a/mypy.ini
+++ b/mypy.ini
@@ -31,3 +31,14 @@ ignore_errors = True
 
 [mypy-openai.*]
 ignore_missing_imports = True
+[mypy-openai.*]
+ignore_missing_imports = True
+
+[mypy-anthropic.*]
+ignore_missing_imports = True
+
+[mypy-google.generativeai.*]
+ignore_missing_imports = True
+
+[mypy-tqdm.*]
+ignore_missing_imports = True


### PR DESCRIPTION
Removed redundant type: ignore[import-not-found] comments from collector.py and added module-specific ignore_missing_imports sections in mypy.ini.