### PR TITLE
Adjust mypy settings

### DIFF
--- a/mypy.ini
+++ b/mypy.ini
@@ -4,13 +4,33 @@ plugins = pydantic.mypy
 files = .
 color_output = True
 show_error_codes = True
-warn_unused_ignores = True
 
 [mypy-src.*]
-strict = True
-
+strict = False
+ignore_missing_imports = True
 [mypy-scripts.*]
 ignore_missing_imports = True
 warn_return_any = False
 disallow_untyped_defs = False
 disallow_incomplete_defs = False
+
+# ---- コア部分だけ厳格 ----
+[mypy-ugh3_metrics_lib.core.*]
+strict = True
+disallow_untyped_defs = True
+disallow_incomplete_defs = True
+
+[mypy-ugh3_metrics_lib.facade.trigger]
+strict = True
+disallow_untyped_defs = True
+disallow_incomplete_defs = True
+
+[mypy-ugh3_metrics_lib.facade.collector]
+strict = True
+disallow_untyped_defs = True
+disallow_incomplete_defs = True
+
+[mypy-ugh3_metrics_lib.secl.qa_cycle]
+strict = True
+disallow_untyped_defs = True
+disallow_incomplete_defs = True


### PR DESCRIPTION
## Summary
- relax default mypy settings and ignore missing imports
- enforce strict typing for core modules

## Testing
- `pytest -q`