### PR TITLE
Fix OpenAI response handling in ai_issue_codegen

### DIFF
--- a/scripts/ai_issue_codegen.py
+++ b/scripts/ai_issue_codegen.py
@@ -46,7 +46,9 @@ def llm(issue_body: str) -> str:
         ],
         temperature=0.0,
     )
-    choice = cast(dict[str, Any], response["choices"][0])
+    if hasattr(response, "choices"):
+        return str(response.choices[0].message.content)
+    choice = cast(dict[str, Any], response["choices"][0])  # type: ignore[index]
     message = cast(dict[str, Any], choice["message"])
     return str(message["content"])
 


### PR DESCRIPTION
## Summary
- handle openai.ChatCompletion objects in `ai_issue_codegen.py`

## Testing
- `python -m pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_683cb467215c83309cb4b687efce20de