### PR TITLE
Fix ChatCompletion handling

### DIFF
--- a/scripts/ai_issue_codegen.py
+++ b/scripts/ai_issue_codegen.py
@@ -46,9 +46,14 @@ def llm(issue_body: str) -> str:
         ],
         temperature=0.0,
     )
-    choice = cast(dict[str, Any], response["choices"][0])
-    message = cast(dict[str, Any], choice["message"])
-    return str(message["content"])
+    content: str
+    if hasattr(response, "choices"):
+        content = response.choices[0].message.content  # type: ignore[assignment]
+    else:
+        choice = cast(dict[str, Any], response["choices"][0])  # type: ignore[index]
+        message = cast(dict[str, Any], choice["message"])
+        content = message["content"]  # type: ignore[assignment]
+    return str(content)
 
 
 def apply_patch(diff_text: str) -> None:


### PR DESCRIPTION
## Summary
- make ai_issue_codegen work with both new & old openai return types
- silence mypy index error for legacy branch

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_683cb0f3e81c83308ae3d1dbb562d84b