### PR TITLE
Fix apply_patch stripping quotes

### DIFF
--- a/scripts/ai_issue_codegen.py
+++ b/scripts/ai_issue_codegen.py
@@ -59,7 +59,7 @@ def llm(issue_body: str) -> str:
 
 def apply_patch(diff_text: str) -> None:
     # --- Strip code-fence lines (` ``` `) that break `patch`
-    diff_text = "\n".join(l for l in diff_text.splitlines() if not l.startswith("```")) + "\n"
+    diff_text = "\n".join(l.lstrip("| ") for l in diff_text.splitlines() if not l.startswith("```")) + "\n"
     # ------------------------------------------------------
     GEN_DIR.mkdir(exist_ok=True)
     patch_path = GEN_DIR / "auto.patch"


### PR DESCRIPTION
## Summary
- support pipes when removing code fences in `apply_patch`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_683cd77f857083309cb1b017633fa029