### PR TITLE
Fix apply_patch header insertion

### DIFF
--- a/scripts/ai_issue_codegen.py
+++ b/scripts/ai_issue_codegen.py
@@ -60,6 +60,11 @@ def llm(issue_body: str) -> str:
 def apply_patch(diff_text: str) -> None:
     # --- Strip code-fence lines (` ``` `) that break `patch`
     diff_text = "\n".join(l.lstrip("| ") for l in diff_text.splitlines() if not l.startswith("```")) + "\n"
+    # auto-insert missing "diff --git" header when LLM omits it
+    if diff_text.lstrip().startswith("--- a/"):
+        first  = diff_text.lstrip().splitlines()[0][4:]
+        second = first.replace("a/", "b/", 1)
+        diff_text = f"diff --git {first} {second}\n" + diff_text
     # ------------------------------------------------------
     GEN_DIR.mkdir(exist_ok=True)
     patch_path = GEN_DIR / "auto.patch"


### PR DESCRIPTION
## Summary
- enhance apply_patch to auto-insert a `diff --git` header if the LLM omits it

## Testing
- `python -m pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_683cdbe8952883309a4fe31bfabe7546