### PR TITLE
Fix patch header handling in ai_issue_codegen

### DIFF
--- a/scripts/ai_issue_codegen.py
+++ b/scripts/ai_issue_codegen.py
@@ -59,12 +59,12 @@ def llm(issue_body: str) -> str:
 
 def apply_patch(diff_text: str) -> None:
     # --- Strip code-fence lines (` ``` `) that break `patch`
-    diff_text = "\n".join(l.lstrip("| ") for l in diff_text.splitlines() if not l.startswith("```")) + "\n"
-    # auto-insert missing "diff --git" header when LLM omits it
-    if diff_text.lstrip().startswith("--- a/"):
-        first  = diff_text.lstrip().splitlines()[0][4:]
+    lines = [l.lstrip("| ") for l in diff_text.splitlines() if not l.startswith("```")]
+    if lines and lines[0].startswith("--- a/"):
+        first = lines[0][4:]
         second = first.replace("a/", "b/", 1)
-        diff_text = f"diff --git {first} {second}\n" + diff_text
+        lines.insert(0, f"diff --git {first} {second}")
+    diff_text = "\n".join(lines) + "\n"
     # ------------------------------------------------------
     GEN_DIR.mkdir(exist_ok=True)
     patch_path = GEN_DIR / "auto.patch"


### PR DESCRIPTION
## Summary
- refine patch pre-processing to add missing `diff --git` header

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_683ce47046788330aa3319d743b49330