### PR TITLE
Fix apply_patch encoding handling

### DIFF
--- a/scripts/ai_issue_codegen.py
+++ b/scripts/ai_issue_codegen.py
@@ -128,9 +128,12 @@ def apply_patch(diff_text: str) -> None:
     for cmd in cmds:
         try:
             print(f"[debug] running: {' '.join(cmd)}")
+            text_input = (
+                diff_text.decode() if isinstance(diff_text, bytes) else diff_text
+            )
             proc = subprocess.run(
                 cmd,
-                input=diff_text.encode(),
+                input=text_input,
                 capture_output=True,
                 text=True,
                 timeout=30,


### PR DESCRIPTION
## Summary
- properly handle diff_text being bytes in `apply_patch`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_683db096863c833096f49942dd62404d