### PR TITLE
Replace subprocess usage in codegen tests

### DIFF
--- a/tests/test_codegen_cli.py
+++ b/tests/test_codegen_cli.py
@@ -1,14 +1,35 @@
-import subprocess
 import sys
+import os
+from unittest.mock import patch
+from io import StringIO
+
+# Add the scripts directory to the Python path so we can import the CLI directly
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "scripts"))
+
+from ai_issue_codegen import main
 
 
 def test_codegen_help() -> None:
-    out = subprocess.check_output([sys.executable, "scripts/ai_issue_codegen.py", "-h"])
-    assert b"usage" in out.lower()
+    """Verify that the CLI prints usage information."""
+    with patch("sys.argv", ["ai_issue_codegen.py", "-h"]):
+        with patch("sys.stdout", new_callable=StringIO) as mock_stdout:
+            try:
+                main()
+            except SystemExit:
+                # argparse exits after printing help
+                pass
+            output = mock_stdout.getvalue()
+            assert "usage" in output.lower()
 
 
 def test_codegen_version() -> None:
-    out = subprocess.check_output(
-        [sys.executable, "scripts/ai_issue_codegen.py", "--version"]
-    )
-    assert b"0.0.1" in out
+    """Verify that the CLI prints its version."""
+    with patch("sys.argv", ["ai_issue_codegen.py", "--version"]):
+        with patch("sys.stdout", new_callable=StringIO) as mock_stdout:
+            try:
+                main()
+            except SystemExit:
+                # argparse exits after printing version
+                pass
+            output = mock_stdout.getvalue()
+            assert "0.0.1" in output


### PR DESCRIPTION
## Summary
- avoid subprocess in tests for ai_issue_codegen CLI
- run the CLI directly via `main()` and patch `sys.argv`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_683de33ff178833098117bb2c4a5aeee