### PR TITLE
Fix issue_body default handling

### DIFF
--- a/.github/workflows/ai_issue_codegen.yml
+++ b/.github/workflows/ai_issue_codegen.yml
@@ -34,7 +34,7 @@ jobs:
         env:
           OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
         run: |
-          python scripts/ai_issue_codegen.py \
+          python scripts/ai_issue_codegen.py --test \
             "${{ github.event.issue.body }}"
 
       # 5) 生成物をコミット & プッシュ → PR 作成

--- a/scripts/ai_issue_codegen.py
+++ b/scripts/ai_issue_codegen.py
@@ -258,9 +258,16 @@ index 1234567..abcdefg 100644
             print(f"[error] Claude Code method failed: {e}")
             sys.exit("❌ patch failed")
 
+    # Handle missing arguments gracefully
     if not args.issue_body and not args.test:
+        # If no arguments provided, automatically enable test mode
+        args.test = True
+        print("[INFO] No arguments provided, automatically running in test mode")
+
+    # If still no issue_body after test mode check, use default
+    if not args.issue_body and args.test:
         args.issue_body = DEFAULT_DIFF
-        print(f"[INFO] Using default issue body: {args.issue_body}")
+        print(f"[INFO] Using default test diff")
 
     try:
         file_operations = parse_unified_diff(args.issue_body)


### PR DESCRIPTION
## Summary
- call ai_issue_codegen with `--test` in workflow
- default to test mode when no args are provided

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_683ded56e65483309cd0ce43f55a18b8