### PR TITLE
Fix GitHub Actions permissions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,6 +6,11 @@ on:
   pull_request:
     branches: [ main ]
 
+permissions:
+  contents: write
+  pull-requests: write
+  issues: read
+
 jobs:
   test:
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Summary
- allow CI workflow to write PRs using `GITHUB_TOKEN`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_683df64921388330b6c3ada0583a6046