### PR TITLE
Add automated Q&A log collection workflow

### DIFF
--- a/.github/workflows/auto-collect.yml
+++ b/.github/workflows/auto-collect.yml
@@ -1,0 +1,41 @@
+name: Auto Collect QA Logs
+
+on:
+  schedule:
+    - cron: '0 6 * * *'
+  workflow_dispatch:
+
+jobs:
+  collect:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+      - name: Cache pip & model
+        uses: actions/cache@v4
+        with:
+          key: python-${{ hashFiles('requirements.txt') }}
+          path: |
+            ~/.cache/pip
+            ~/.cache/torch/sentence_transformers
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -r requirements.txt
+      - name: Run collector
+        env:
+          OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
+        id: collect
+        run: |
+          python facade/collector.py --auto -n 50 --q-provider openai --ai-provider openai --quiet --summary
+          run_dir=$(ls -td runs/* 2>/dev/null | head -n 1 || true)
+          echo "run_dir=$run_dir" >> "$GITHUB_OUTPUT"
+      - name: Upload artifact
+        uses: actions/upload-artifact@v4
+        if: steps.collect.outputs.run_dir != ''
+        with:
+          name: por_history
+          path: ${{ steps.collect.outputs.run_dir }}/por_history.csv
+          retention-days: 30


### PR DESCRIPTION
## Summary
- add cache for pip & model path to GitHub Actions
- ensure artifact upload is safe and kept for 30 days
- avoid failure when runs directory is missing

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6847c7e5cd288330ae925ca758121c1f