### PR TITLE
AUTO: add scoring/analysis pipeline improvements

### DIFF
--- a/.github/workflows/auto-por-daily.yml
+++ b/.github/workflows/auto-por-daily.yml
@@ -1,0 +1,57 @@
+name: Auto PoR Pipeline
+
+on:
+  schedule:
+    - cron: '0 6 * * *'
+  workflow_dispatch:
+
+jobs:
+  por-pipeline:
+    runs-on: ubuntu-latest
+    timeout-minutes: 60   # BLEURT モデルDLの余裕確保
+    env:
+      OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.10'
+
+      - name: Cache HF models
+        uses: actions/cache@v4
+        with:
+          path: ~/.cache/huggingface
+          key: ${{ runner.os }}-hf-${{ hashFiles('requirements.txt') }}
+
+      - name: Install deps
+        run: |
+          pip install -r requirements.txt
+          pip install bert-score evaluate matplotlib seaborn scikit-learn
+
+      - name: Collect 50 QA pairs
+        run: |
+          python facade/collector.py --auto -n 50 \
+            --q-provider openai --ai-provider openai \
+            --quiet --output daily_raw.csv
+
+      - name: Score baseline metrics
+        run: |
+          python scripts/auto_score.py \
+            --input daily_raw.csv --output daily_scored.csv
+
+      - name: Analyze & generate report
+        run: |
+          REPORT_DIR="reports/$(date +%Y%m%d)"
+          mkdir -p "$REPORT_DIR"
+          python scripts/auto_analysis.py \
+            --input daily_scored.csv --report-dir "$REPORT_DIR"
+
+      - name: Upload artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: por_dataset_${{ github.run_number }}
+          path: |
+            daily_scored.csv
+            ${{ github.workspace }}/reports/**
+          if-no-files-found: ignore

--- a/facade/collector.py
+++ b/facade/collector.py
@@ -490,7 +490,13 @@ def run_cycle(
 def main(argv: List[str] | None = None) -> None:
     """Command line interface for the collector."""
     parser = argparse.ArgumentParser(description="PoR/ΔE/grv collector")
-    parser.add_argument("-n", "--steps", type=int, default=10, help="number of cycles")
+    parser.add_argument(
+        "-n",
+        "--steps",
+        type=int,
+        default=50,
+        help="number of cycles",
+    )
     parser.add_argument(
         "-o",
         "--output",

--- a/scripts/auto_analysis.py
+++ b/scripts/auto_analysis.py
@@ -1,0 +1,99 @@
+import argparse
+import os
+from typing import Tuple
+
+import pandas as pd
+import numpy as np
+import matplotlib
+matplotlib.use("Agg")  # CI 環境向け
+import matplotlib.pyplot as plt
+import seaborn as sns
+from scipy import stats
+
+
+def cohens_d(x: np.ndarray, y: np.ndarray) -> float:
+    diff = x - y
+    return diff.mean() / diff.std(ddof=1)
+
+
+def bootstrap_ci(data: np.ndarray, func, n_boot: int = 1000, alpha: float = 0.05) -> Tuple[float, float]:
+    rng = np.random.default_rng(0)
+    stats_ = []
+    for _ in range(n_boot):
+        sample = rng.choice(data, size=len(data), replace=True)
+        stats_.append(func(sample))
+    lower = np.percentile(stats_, 100 * alpha / 2)
+    upper = np.percentile(stats_, 100 * (1 - alpha / 2))
+    return float(lower), float(upper)
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Analyze scored QA dataset")
+    parser.add_argument("--input", required=True, help="scored CSV path")
+    parser.add_argument("--report-dir", required=True, help="output directory")
+    args = parser.parse_args()
+
+    os.makedirs(args.report_dir, exist_ok=True)
+    df = pd.read_csv(args.input)
+
+    metrics = ["por", "delta_e", "grv", "bertscore", "bleurt", "rougeL"]
+
+    for m in metrics:
+        plt.figure()
+        sns.histplot(df[m].dropna(), kde=True)
+        plt.title(f"{m} distribution")
+        plt.savefig(os.path.join(args.report_dir, f"{m}_hist.png"))
+        plt.close()
+
+        plt.figure()
+        sns.boxplot(x=df[m].dropna())
+        plt.title(f"{m} boxplot")
+        plt.savefig(os.path.join(args.report_dir, f"{m}_box.png"))
+        plt.close()
+
+    corr = df[metrics].corr()
+    plt.figure(figsize=(8, 6))
+    sns.heatmap(corr, annot=True, cmap="coolwarm")
+    plt.title("Correlation Heatmap")
+    plt.savefig(os.path.join(args.report_dir, "correlation_heatmap.png"))
+    plt.close()
+
+    results = []
+    baseline = ["bertscore", "bleurt", "rougeL"]
+    bonf_factor = len(baseline)
+    for m in baseline:
+        paired = df[["por", m]].dropna()
+        x = paired["por"].to_numpy()
+        y = paired[m].to_numpy()
+        t_stat, p_val = stats.ttest_rel(x, y)
+        diff = x - y
+        sem = diff.std(ddof=1) / np.sqrt(len(diff))
+        ci_low = diff.mean() - 1.96 * sem
+        ci_high = diff.mean() + 1.96 * sem
+        bs_low, bs_high = bootstrap_ci(diff, np.mean)
+        d = cohens_d(x, y)
+        results.append(
+            {
+                "metric": m,
+                "t_stat": t_stat,
+                "p_val": min(1.0, p_val * bonf_factor),
+                "cohens_d": d,
+                "95CI_low": ci_low,
+                "95CI_high": ci_high,
+                "boot_low": bs_low,
+                "boot_high": bs_high,
+            }
+        )
+
+    summary_path = os.path.join(args.report_dir, "ttest_summary.csv")
+    pd.DataFrame(results).to_csv(summary_path, index=False)
+
+    if "adopted" in df.columns:
+        adoption_rate = df[df["adopted"] == 1].shape[0] / max(1, df.shape[0])
+        pd.DataFrame({"adoption_rate": [adoption_rate]}).to_csv(
+            os.path.join(args.report_dir, "adoption_summary.csv"), index=False
+        )
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/auto_score.py
+++ b/scripts/auto_score.py
@@ -1,0 +1,68 @@
+import argparse
+import warnings
+
+import numpy as np
+import pandas as pd
+from bert_score import score as bert_score
+import evaluate
+
+warnings.filterwarnings("ignore", category=FutureWarning)
+
+
+def classify_domain(text: str) -> str:
+    """Rudimentary domain classifier based on keywords."""
+    t = text.lower()
+    tech_kw = ["code", "algorithm", "python", "api", "技術", "テク", "アルゴリズム"]
+    creative_kw = ["story", "fiction", "novel", "poem", "物語", "創作"]
+    specialized_kw = ["医学", "法律", "finance", "経済", "化学", "物理"]
+    if any(k in t for k in tech_kw):
+        return "technical"
+    if any(k in t for k in creative_kw):
+        return "creative"
+    if any(k in t for k in specialized_kw):
+        return "specialized"
+    return "general"
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Score QA pairs with baseline metrics")
+    parser.add_argument("--input", required=True, help="input CSV path")
+    parser.add_argument("--output", required=True, help="output CSV path")
+    args = parser.parse_args()
+
+    df = pd.read_csv(args.input)
+
+    candidates = df["answer"].astype(str).tolist()
+    references = df["question"].astype(str).tolist()
+
+    # BERTScore
+    _, _, f1 = bert_score(candidates, references, lang="multilingual", rescale_with_baseline=True)
+    # bert_score は torch.Tensor を返すので Python list に変換
+    df["bertscore"] = f1.cpu().numpy().tolist()
+
+    rouge = evaluate.load("rouge")
+    rouge_res = rouge.compute(predictions=candidates, references=references)
+    df["rougeL"] = rouge_res["rougeL"]
+
+    # BLEURT: 日本語でモデルが無い場合は NaN を埋める
+    try:
+        bleurt = evaluate.load("bleurt")
+        bleurt_res = bleurt.compute(predictions=candidates, references=references)
+        df["bleurt"] = bleurt_res["scores"]
+    except Exception:
+        df["bleurt"] = np.nan
+
+    df["domain"] = df["question"].apply(classify_domain)
+
+    metrics = ["por", "delta_e", "grv", "bertscore", "bleurt", "rougeL"]
+    adopt = np.ones(len(df), dtype=bool)
+    for m in metrics:
+        q_low, q_high = df[m].quantile([0.05, 0.95]).values
+        adopt &= (df[m] >= q_low) & (df[m] <= q_high)
+    df["adopted"] = adopt.astype(int)
+
+    df.to_csv(args.output, index=False)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- improve BERTScore, ROUGE and BLEURT handling in `auto_score`
- make analysis script non-interactive and adopt-aware
- cache HuggingFace models and extend timeout in workflow

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68490c5955588330ae495d5b70fc9ca0