### PR TITLE
Add step to copy daily_raw csv from latest run

### DIFF
--- a/.github/workflows/auto-por-daily.yml
+++ b/.github/workflows/auto-por-daily.yml
@@ -40,6 +40,15 @@ jobs:
             --q-provider openai --ai-provider openai \
             --quiet --output daily_raw.csv
 
+      # ---- new step: copy the generated CSV from runs/<latest>/ ----
+      - name: Extract daily_raw.csv
+        run: |
+          # 直近で作られた runs ディレクトリを検出
+          LATEST=$(ls -td runs/* | head -n 1)
+          echo "Latest runs dir: $LATEST"
+          cp "$LATEST/daily_raw.csv" ./daily_raw.csv
+          ls -l ./daily_raw.csv   # デバッグ表示
+
       - name: Score baseline metrics
         run: |
           python scripts/auto_score.py \


### PR DESCRIPTION
## Summary
- in the Auto PoR workflow, after collecting QA pairs, pull `daily_raw.csv` from the newest `runs` directory

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684adcda78a08330869761ed16597e46