### PR TITLE
Implement COMET-Kiwi scoring and update deps

### DIFF
--- a/.github/workflows/auto-por-daily.yml
+++ b/.github/workflows/auto-por-daily.yml
@@ -31,6 +31,13 @@ jobs:
           pip install -r requirements.txt
           # 追加: パッケージを editable でインストール
           pip install -e .
+      - name: Warm cache – COMET-Kiwi
+        run: |
+          python - << 'PY'
+from comet.download_utils import download_model
+download_model("Unbabel/wmt22-cometkiwi-da")
+print("COMET-Kiwi ready.")
+PY
 
       - name: Collect 50 QA pairs
         run: |

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,7 +5,9 @@ numpy>=1.22             # for numpy typing stubs
 rouge-score>=0.1.2      # 日本語Rouge-L用
 fugashi>=1.3            # MeCab wrapper
 ipadic>=1.0             # MeCab dictionary
-unbabel-comet>=2.3.0    # COMET-Kiwi（多言語BLEURT代替）
+# COMET-Kiwi (多言語BLEURT代替) ── 2.2.6 が最新
+# 2.3 系はまだ PyPI に無いので、2.2 系に固定
+unbabel-comet==2.2.6
 seaborn
 bert-score
 mypy

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,12 +2,12 @@ matplotlib
 pytest
 pandas
 numpy>=1.22             # for numpy typing stubs
-rouge-score>=0.1.2      # evaluate/rouge dependency
-nltk>=3.8               # evaluate/rouge dependency
-absl-py>=1.0            # evaluate/rouge dependency
+rouge-score>=0.1.2      # 日本語Rouge-L用
+fugashi>=1.3            # MeCab wrapper
+ipadic>=1.0             # MeCab dictionary
+unbabel-comet>=2.3.0    # COMET-Kiwi（多言語BLEURT代替）
 seaborn
 bert-score
-evaluate
 mypy
 types-PyYAML          # for mypy stub of PyYAML
 # ---------------- core ML / NLP 依存 ----------------

--- a/scripts/auto_analysis.py
+++ b/scripts/auto_analysis.py
@@ -42,7 +42,7 @@ def main() -> None:
     os.makedirs(args.report_dir, exist_ok=True)
     df = pd.read_csv(args.input)
 
-    metrics = ["por", "delta_e", "grv", "bertscore", "bleurt", "rougeL"]
+    metrics = ["por", "delta_e", "grv", "bertscore", "cometkiwi", "rougeL"]
 
     for m in metrics:
         plt.figure()
@@ -65,7 +65,7 @@ def main() -> None:
     plt.close()
 
     results = []
-    baseline = ["bertscore", "bleurt", "rougeL"]
+    baseline = ["bertscore", "cometkiwi", "rougeL"]
     bonf_factor = len(baseline)
     for m in baseline:
         paired = df[["por", m]].dropna()


### PR DESCRIPTION
## Summary
- remove evaluate and old rouge/BLEURT dependencies
- add fugashi/ipadic and unbabel-comet for COMET-Kiwi
- refactor `auto_score.py` to compute COMET-Kiwi and Japanese Rouge-L
- update analysis script metric lists
- cache COMET-Kiwi model in daily workflow

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684b5eaadd9483309a9697ea2f5799a1