### PR TITLE
Fix collector default steps and workflow param

### DIFF
--- a/.github/workflows/build-dataset.yml
+++ b/.github/workflows/build-dataset.yml
@@ -38,7 +38,7 @@ jobs:
           PYTHONPATH: ${{ github.workspace }}
         run: |
           # 1) Q&A 生成 → dialogs.csv を runs/<exp_id>/ に保存
-          python facade/collector.py --auto -n ${{ inputs.turns }} \
+          python facade/collector.py --auto -n 50 \
           --q-provider openai --ai-provider openai \
           --quiet --summary \
           --output dialogs.csv

--- a/facade/collector.py
+++ b/facade/collector.py
@@ -495,7 +495,7 @@ def main(argv: List[str] | None = None) -> None:
         "--steps",
         type=int,
         default=50,
-        help="number of cycles",
+        help="number of cycles (default: 50)",
     )
     parser.add_argument(
         "-o",


### PR DESCRIPTION
## Summary
- ensure GitHub Actions pass a numeric `-n` value to `collector.py`
- mention default in collector CLI help text

## Testing
- `pytest -q`
- `PYTHONPATH=. python facade/collector.py -h | head -n 15`

------
https://chatgpt.com/codex/tasks/task_e_684c2983b0cc8330a88723153cc5e2cd