### PR TITLE
Implement stratified QA generation

### DIFF
--- a/README.md
+++ b/README.md
@@ -201,6 +201,7 @@ PoR scores over time. Running the script will save an image to
 # 手動テスト (GitHub Actions の Run workflow でも可)
 python facade/collector.py --auto -n 10 --q-provider openai --ai-provider openai \
   --quiet --summary --output test_por.csv
+# ドメインと難易度は内部で自動的にばらつきを付けて生成されます
 
 <details>
 <summary>Mermaid Flow</summary>graph TD

--- a/tests/test_examples.py
+++ b/tests/test_examples.py
@@ -51,6 +51,8 @@ def test_run_cycle_generates_csv(tmp_path: Path) -> None:
         "por",
         "delta_e",
         "grv",
+        "domain",
+        "difficulty",
         "timestamp",
     ]
     assert 1 <= len(rows) <= steps


### PR DESCRIPTION
## Summary
- add `stratified_pairs` to generate domain/difficulty pairs
- expand `HistoryEntry` schema with domain and difficulty
- insert stratified sampling in `run_cycle`
- embed domain and difficulty in question prompt
- update CLI help and README snippet
- adjust tests for new CSV schema

## Testing
- `python -m mypy .`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684c5f79d62c8330b5cc92636b04ba6d