### PR TITLE
fix(ci): restore COMET-Kiwi cache snippet inside guard block

### DIFF
--- a/.github/workflows/auto-por-daily.yml
+++ b/.github/workflows/auto-por-daily.yml
@@ -33,11 +33,13 @@ jobs:
           pip install -e .
       - name: Warm cache – COMET-Kiwi
         run: |
-          python - << 'PY'
-from comet.download_utils import download_model
-download_model("Unbabel/wmt22-cometkiwi-da")
-print("COMET-Kiwi ready.")
-PY
+          # #### BEGIN COMET-CACHE
+          python - <<'PY'
+          from comet.download_utils import download_model
+          download_model("Unbabel/wmt22-cometkiwi-da")
+          print("COMET-Kiwi ready.")
+          PY
+          # #### END COMET-CACHE
 
       - name: Collect 50 QA pairs
         run: |


### PR DESCRIPTION
## Summary
- restore and wrap COMET-Kiwi cache snippet inside guarded block

## Testing
- `pytest -q`
- `actionlint` *(fails: command not found)*
- `yamllint .github/workflows/auto-por-daily.yml` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685634d48124833089c0db1559632deb