### PR TITLE
Fix COMET import in warm_cache and add tests

### DIFF
--- a/tests/warm_cache_test.py
+++ b/tests/warm_cache_test.py
@@ -1,0 +1,41 @@
+import subprocess
+import sys
+import os
+from pathlib import Path
+
+
+# prepare fake comet package for subprocess and module import
+FAKE_DIR = Path('temp_comet')
+(FAKE_DIR / 'comet' / 'downloaders').mkdir(parents=True, exist_ok=True)
+code = 'def download_model(name):\n    pass\n'
+(FAKE_DIR / 'comet' / 'download_utils.py').write_text(code)
+(FAKE_DIR / 'comet' / '__init__.py').write_text('\n')
+(FAKE_DIR / 'comet' / 'downloaders' / '__init__.py').write_text('\n')
+(FAKE_DIR / 'comet' / 'downloaders' / 'download_utils.py').write_text(code)
+
+sys.path.insert(0, str(FAKE_DIR))
+
+import warm_cache
+
+
+def test_cli_help() -> None:
+    env = dict(PYTHONPATH=str(FAKE_DIR))
+    result = subprocess.run(
+        [sys.executable, 'warm_cache.py', '--help'],
+        capture_output=True,
+        text=True,
+        env={**env, **{k: v for k, v in os.environ.items() if k not in env}},
+    )
+    assert result.returncode == 0
+    assert 'Warm COMET model cache' in result.stdout
+
+
+def test_download_models(monkeypatch) -> None:
+    called = []
+
+    def fake_download(model: str) -> None:
+        called.append(model)
+
+    monkeypatch.setattr(warm_cache, 'download_model', fake_download)
+    warm_cache.download_models(['a', 'b'])
+    assert called == ['a', 'b']

--- a/tests/warm_cache_test.py
+++ b/tests/warm_cache_test.py
@@ -2,6 +2,7 @@ import subprocess
 import sys
 import os
 from pathlib import Path
+from _pytest.monkeypatch import MonkeyPatch  # type: ignore[import-not-found,unused-ignore]
 
 
 # prepare fake comet package for subprocess and module import
@@ -30,8 +31,8 @@ def test_cli_help() -> None:
     assert 'Warm COMET model cache' in result.stdout
 
 
-def test_download_models(monkeypatch) -> None:
-    called = []
+def test_download_models(monkeypatch: MonkeyPatch) -> None:
+    called: list[str] = []
 
     def fake_download(model: str) -> None:
         called.append(model)

--- a/warm_cache.py
+++ b/warm_cache.py
@@ -1,0 +1,30 @@
+try:
+    from comet.download_utils import download_model  # COMET < 2.0
+except ModuleNotFoundError:  # pragma: no cover
+    try:
+        from comet.downloaders.download_utils import download_model  # COMET ≥ 2.0
+    except ModuleNotFoundError as exc:  # pragma: no cover
+        raise ModuleNotFoundError(
+            "サポートされていない COMET 版です。"
+            "対応バージョンをインストールするか、import ロジックを更新してください。"
+        ) from exc
+
+import argparse
+from typing import List
+
+def download_models(models: List[str]) -> None:
+    for model in models:
+        print(f"Downloading {model} ...")
+        download_model(model)
+        print("done.")
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Warm COMET model cache")
+    parser.add_argument("models", nargs="+", help="COMET model names")
+    args = parser.parse_args()
+    download_models(args.models)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- add `warm_cache.py` with fallback import paths for COMET v1/v2
- provide helpful error when unsupported COMET is detected
- test CLI and API behaviour with fake COMET modules

## Testing
- `python -m pytest -q tests/warm_cache_test.py`
- `python -m pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6856a66dddec8330bbef79aea831e826