### PR TITLE
Fix GRV PMI calculation and update tests

### DIFF
--- a/core/__init__.py
+++ b/core/__init__.py
@@ -1,12 +1,24 @@
 from .deltae import deltae_score
 from .grv import grv_score
+from .delta_e_v4 import score as delta_e_v4, set_params as set_deltae_params
+from .grv_v4 import score as grv_v4, set_params as set_grv_params
+from .por_v4 import score as por_score, set_params as set_por_params
+from .sci import score as sci, set_weights as set_sci_weights
 from .history import evaluate_record, GOOD, OKAY, BAD
 
 __all__ = [
     "deltae_score",
     "grv_score",
+    "delta_e_v4",
+    "grv_v4",
+    "por_score",
+    "sci",
     "evaluate_record",
     "GOOD",
     "OKAY",
     "BAD",
+    "set_deltae_params",
+    "set_grv_params",
+    "set_por_params",
+    "set_sci_weights",
 ]

--- a/core/delta_e_v4.py
+++ b/core/delta_e_v4.py
@@ -2,7 +2,8 @@
 
 from __future__ import annotations
 
-from typing import Optional
+from typing import Optional, Any
+from numpy.typing import NDArray
 
 import numpy as np
 try:
@@ -11,7 +12,8 @@ except Exception:  # pragma: no cover - fallback if library missing
     class SentenceTransformer:  # type: ignore
         def __init__(self, *args: str, **kwargs: str) -> None:
             pass
-        def encode(self, text: str) -> np.ndarray:  # pragma: no cover
+
+        def encode(self, text: str) -> NDArray[Any]:  # pragma: no cover
             return np.zeros(1, dtype=float)
 
 _EMBEDDER: Optional[SentenceTransformer] = None

--- a/core/delta_e_v4.py
+++ b/core/delta_e_v4.py
@@ -1,0 +1,61 @@
+"""ΔE v4 metric using semantic difference."""
+
+from __future__ import annotations
+
+from typing import Optional
+
+import numpy as np
+try:
+    from sentence_transformers import SentenceTransformer
+except Exception:  # pragma: no cover - fallback if library missing
+    class SentenceTransformer:  # type: ignore
+        def __init__(self, *args: str, **kwargs: str) -> None:
+            pass
+        def encode(self, text: str) -> np.ndarray:  # pragma: no cover
+            return np.zeros(1, dtype=float)
+
+_EMBEDDER: Optional[SentenceTransformer] = None
+
+DEFAULT_MU: float = 0.35
+DEFAULT_SIGMA: float = 0.08
+
+
+def _get_embedder() -> SentenceTransformer:
+    """Return cached ``SentenceTransformer`` instance."""
+    global _EMBEDDER
+    if _EMBEDDER is None:
+        _EMBEDDER = SentenceTransformer("all-MiniLM-L6-v2")
+    return _EMBEDDER
+
+
+def set_params(mu: float | None = None, sigma: float | None = None) -> None:
+    """Set z-score parameters."""
+    global DEFAULT_MU, DEFAULT_SIGMA
+    if mu is not None:
+        DEFAULT_MU = float(mu)
+    if sigma is not None:
+        DEFAULT_SIGMA = float(sigma)
+
+
+def delta_e(prev: Optional[str], curr: str) -> float:
+    """Return standardized cosine difference clipped to [0, 1]."""
+    if prev is None:
+        return 0.0
+
+    emb = _get_embedder()
+    v1 = emb.encode(prev)
+    v2 = emb.encode(curr)
+    num = float(np.dot(v1, v2))
+    denom = float(np.linalg.norm(v1) * np.linalg.norm(v2))
+    sim = num / denom if denom else 0.0
+    diff = 1.0 - sim
+
+    z = (diff - DEFAULT_MU) / DEFAULT_SIGMA if DEFAULT_SIGMA else diff - DEFAULT_MU
+    return float(np.clip(z, 0.0, 1.0))
+
+
+# backward compatibility
+score = delta_e
+
+
+__all__ = ["score", "set_params"]

--- a/core/grv_v4.py
+++ b/core/grv_v4.py
@@ -5,7 +5,8 @@ from __future__ import annotations
 import numpy as np
 from collections import Counter
 from math import log
-from typing import Iterable, List, Optional
+from typing import Iterable, List, Optional, Any
+from numpy.typing import NDArray
 
 try:
     from sklearn.feature_extraction.text import TfidfVectorizer
@@ -14,7 +15,7 @@ except Exception:  # pragma: no cover - fallback if sklearn missing
         def __init__(self) -> None:
             self._arr = np.zeros((1, 0))
 
-        def toarray(self) -> np.ndarray:  # pragma: no cover - mimic sklearn matrix
+        def toarray(self) -> NDArray[Any]:  # pragma: no cover - mimic sklearn matrix
             return self._arr
 
     class TfidfVectorizer:  # type: ignore
@@ -32,7 +33,7 @@ except Exception:  # pragma: no cover - fallback if sklearn missing
             self.fit(docs)
             return _DummyMatrix()
 
-DEFAULT_WEIGHTS: np.ndarray = np.array([0.42, 0.31, 0.27])
+DEFAULT_WEIGHTS: NDArray[Any] = np.array([0.42, 0.31, 0.27])
 
 _VECTORIZER: Optional[TfidfVectorizer] = None
 

--- a/core/grv_v4.py
+++ b/core/grv_v4.py
@@ -1,0 +1,151 @@
+"""Vocabulary Gravity v4 metric."""
+
+from __future__ import annotations
+
+import numpy as np
+from collections import Counter
+from math import log
+from typing import Iterable, List, Optional
+
+try:
+    from sklearn.feature_extraction.text import TfidfVectorizer
+except Exception:  # pragma: no cover - fallback if sklearn missing
+    class _DummyMatrix:
+        def __init__(self) -> None:
+            self._arr = np.zeros((1, 0))
+
+        def toarray(self) -> np.ndarray:  # pragma: no cover - mimic sklearn matrix
+            return self._arr
+
+    class TfidfVectorizer:  # type: ignore
+        def __init__(self) -> None:
+            self.vocabulary_: dict[str, int] = {}
+
+        def fit(self, docs: Iterable[str]) -> "TfidfVectorizer":
+            self.vocabulary_ = {}
+            return self
+
+        def transform(self, docs: Iterable[str]) -> _DummyMatrix:
+            return _DummyMatrix()
+
+        def fit_transform(self, docs: Iterable[str]) -> _DummyMatrix:
+            self.fit(docs)
+            return _DummyMatrix()
+
+DEFAULT_WEIGHTS: np.ndarray = np.array([0.42, 0.31, 0.27])
+
+_VECTORIZER: Optional[TfidfVectorizer] = None
+
+
+def set_params(weights: Iterable[float]) -> None:
+    """Set feature weights."""
+    global DEFAULT_WEIGHTS
+    arr = np.asarray(list(weights), dtype=float)
+    if arr.size != 3:
+        raise ValueError("weights must have length 3")
+    DEFAULT_WEIGHTS = arr
+
+
+def _get_vectorizer(text: str) -> TfidfVectorizer:
+    """Return cached ``TfidfVectorizer`` fitted on first real text."""
+    global _VECTORIZER
+    if _VECTORIZER is None:
+        _VECTORIZER = TfidfVectorizer()
+    if not getattr(_VECTORIZER, "vocabulary_", None):
+        try:
+            _VECTORIZER.fit([text])
+        except Exception:  # pragma: no cover - fallback for stub
+            pass
+    return _VECTORIZER
+
+
+def _tokenize(items: str | Iterable[str]) -> list[str]:
+    if isinstance(items, str):
+        texts = [items]
+    else:
+        texts = list(items)
+    tokens: list[str] = []
+    for t in texts:
+        tokens.extend(t.split())
+    return tokens
+
+
+def _tfidf_score(tokens: List[str]) -> float:
+    """Return TF-IDF density using a cached vectorizer."""
+    text = " ".join(tokens)
+    vec = _get_vectorizer(text)
+    try:
+        row = vec.transform([text])
+    except Exception:  # pragma: no cover - stub fallback
+        row = vec.fit_transform([text])
+    arr = row.toarray().ravel()
+    if arr.size == 0:
+        return 0.0
+    k = min(30, arr.size)
+    top_k = np.sort(arr)[-k:]
+    return float(np.sum(top_k) / 30.0)
+
+
+def _entropy_score(tokens: List[str]) -> float:
+    counts = Counter(tokens)
+    n = len(tokens)
+    probs = [c / n for c in counts.values()]
+    ent = -sum(p * log(p) for p in probs if p > 0)
+    max_ent = log(len(counts)) if len(counts) > 1 else 1.0
+    return float(ent / max_ent)
+
+
+def _pmi_score(tokens: List[str]) -> float:
+    """Return average pairwise PMI within a 50-token window."""
+    if len(tokens) < 2:
+        return 0.0
+
+    pair_freq: Counter[tuple[str, str]] = Counter()
+    word_freq = Counter(tokens)
+    for i, w1 in enumerate(tokens[:-1]):
+        for w2 in tokens[i + 1 : i + 51]:
+            pair_freq[(w1, w2)] += 1
+
+    total_pairs = sum(pair_freq.values())
+    pmi_sum = 0.0
+    for (w1, w2), freq in pair_freq.items():
+        p_xy = freq / total_pairs
+        p_x = word_freq[w1] / len(tokens)
+        p_y = word_freq[w2] / len(tokens)
+        pmi_sum += np.log2(p_xy / (p_x * p_y))
+
+    return float(pmi_sum / total_pairs) if total_pairs else 0.0
+
+
+def grv(
+    text: str | Iterable[str],
+    *,
+    weights: Iterable[float] | None = None,
+) -> float:
+    """Return vocabulary gravity using TF-IDF, entropy and PMI."""
+    tokens = _tokenize(text)
+    if not tokens:
+        return 0.0
+
+    w = (
+        np.asarray(list(weights), dtype=float)
+        if weights is not None
+        else DEFAULT_WEIGHTS
+    )
+    if w.size != 3:
+        raise ValueError("weights must have length 3")
+    w = w / w.sum()
+    vals = np.array([
+        _tfidf_score(tokens),
+        _entropy_score(tokens),
+        _pmi_score(tokens),
+    ])
+    x = float(np.dot(w, vals))
+    return float(1.0 / (1.0 + np.exp(-x)))
+
+
+# backward compatibility
+score = grv
+
+
+__all__ = ["score", "set_params"]

--- a/core/por_v4.py
+++ b/core/por_v4.py
@@ -1,0 +1,56 @@
+"""Point of Resonance v4 metric."""
+
+from __future__ import annotations
+
+from typing import Optional
+
+import numpy as np
+try:
+    from sentence_transformers import SentenceTransformer
+except Exception:  # pragma: no cover - fallback for environments without the lib
+    class SentenceTransformer:  # type: ignore
+        def __init__(self, *args: str, **kwargs: str) -> None:
+            pass
+        def encode(self, text: str) -> np.ndarray:  # pragma: no cover
+            return np.zeros(1, dtype=float)
+
+_EMBEDDER: Optional[SentenceTransformer] = None
+
+DEFAULT_ALPHA: float = 13.2
+DEFAULT_BETA: float = -10.8
+
+
+def _get_embedder() -> SentenceTransformer:
+    """Return a cached ``SentenceTransformer`` instance."""
+    global _EMBEDDER
+    if _EMBEDDER is None:
+        _EMBEDDER = SentenceTransformer("all-MiniLM-L6-v2")
+    return _EMBEDDER
+
+
+def set_params(alpha: float | None = None, beta: float | None = None) -> None:
+    """Set logistic parameters."""
+    global DEFAULT_ALPHA, DEFAULT_BETA
+    if alpha is not None:
+        DEFAULT_ALPHA = float(alpha)
+    if beta is not None:
+        DEFAULT_BETA = float(beta)
+
+
+def score(prev: str | None, curr: str) -> float:
+    """Return PoR probability from text similarity."""
+    if prev is None:
+        return 0.0
+
+    emb = _get_embedder()
+    v1 = emb.encode(prev)
+    v2 = emb.encode(curr)
+    num = float(np.dot(v1, v2))
+    denom = float(np.linalg.norm(v1) * np.linalg.norm(v2))
+    sim = num / denom if denom else 0.0
+
+    value = 1.0 / (1.0 + np.exp(-(DEFAULT_ALPHA * sim + DEFAULT_BETA)))
+    return float(value)
+
+
+__all__ = ["score", "set_params"]

--- a/core/por_v4.py
+++ b/core/por_v4.py
@@ -2,7 +2,8 @@
 
 from __future__ import annotations
 
-from typing import Optional
+from typing import Optional, Any
+from numpy.typing import NDArray
 
 import numpy as np
 try:
@@ -11,7 +12,8 @@ except Exception:  # pragma: no cover - fallback for environments without the li
     class SentenceTransformer:  # type: ignore
         def __init__(self, *args: str, **kwargs: str) -> None:
             pass
-        def encode(self, text: str) -> np.ndarray:  # pragma: no cover
+
+        def encode(self, text: str) -> NDArray[Any]:  # pragma: no cover
             return np.zeros(1, dtype=float)
 
 _EMBEDDER: Optional[SentenceTransformer] = None

--- a/core/sci.py
+++ b/core/sci.py
@@ -1,0 +1,72 @@
+"""Semantic Consistency Index."""
+
+from __future__ import annotations
+
+import numpy as np
+from typing import Iterable, Sequence
+
+DEFAULT_WEIGHTS: np.ndarray = np.array([0.4, 0.45, 0.15])
+DEFAULT_ALPHA: float = 0.3
+_STATE: float | None = None
+
+
+def set_weights(weights: Sequence[float], alpha: float | None = None) -> None:
+    """Set global weights and EMA parameter."""
+    global DEFAULT_WEIGHTS, DEFAULT_ALPHA
+    arr = np.asarray(list(weights), dtype=float)
+    if arr.size != 3:
+        raise ValueError("weights must have length 3")
+    DEFAULT_WEIGHTS = arr
+    if alpha is not None:
+        DEFAULT_ALPHA = float(alpha)
+
+
+def reset_state() -> None:
+    """Reset internal EMA state."""
+    global _STATE
+    _STATE = None
+
+
+def sci(
+    por: float,
+    delta_e: float,
+    grv: float,
+    *,
+    weights: Iterable[float] | None = None,
+    alpha: float | None = None,
+) -> float:
+    """Return EMA of weighted metrics.
+
+    Parameters
+    ----------
+    por, delta_e, grv : float
+        Input metrics in the range 0.0 to 1.0.
+    weights : Iterable[float], optional
+        Custom weights ``(w1, w2, w3)``.
+
+    Returns
+    -------
+    float
+        Weighted score between 0.0 and 1.0.
+    """
+    w = (
+        np.asarray(list(weights), dtype=float)
+        if weights is not None
+        else DEFAULT_WEIGHTS
+    )
+    if w.size != 3:
+        raise ValueError("weights must have length 3")
+    w = w / w.sum()
+    vals = np.array([por, 1.0 - delta_e, grv], dtype=float)
+    x = float(np.dot(w, vals))
+    a = DEFAULT_ALPHA if alpha is None else float(alpha)
+    global _STATE
+    _STATE = x if _STATE is None else a * x + (1 - a) * _STATE
+    return float(_STATE)
+
+
+# backward compatibility
+score = sci
+
+
+__all__ = ["sci", "score", "set_weights", "reset_state"]

--- a/core/sci.py
+++ b/core/sci.py
@@ -3,9 +3,10 @@
 from __future__ import annotations
 
 import numpy as np
-from typing import Iterable, Sequence
+from typing import Iterable, Sequence, Any
+from numpy.typing import NDArray
 
-DEFAULT_WEIGHTS: np.ndarray = np.array([0.4, 0.45, 0.15])
+DEFAULT_WEIGHTS: NDArray[Any] = np.array([0.4, 0.45, 0.15])
 DEFAULT_ALPHA: float = 0.3
 _STATE: float | None = None
 

--- a/tests/test_metrics_v4.py
+++ b/tests/test_metrics_v4.py
@@ -32,13 +32,13 @@ class DummyEmbedder:
 
 class TestMetricsV4(unittest.TestCase):
     @patch("core.por_v4._get_embedder", return_value=DummyEmbedder())
-    def test_por_score(self, mock_emb) -> None:
+    def test_por_score(self, mock_emb: Any) -> None:
         val = por_v4.score("a", "b")
         self.assertGreaterEqual(val, 0.0)
         self.assertLessEqual(val, 1.0)
 
     @patch("core.delta_e_v4._get_embedder", return_value=DummyEmbedder())
-    def test_delta_e_v4(self, mock_emb) -> None:
+    def test_delta_e_v4(self, mock_emb: Any) -> None:
         val = delta_e_v4.delta_e("hello", "hello world")
         self.assertAlmostEqual(val, 0.375, places=3)
 

--- a/tests/test_metrics_v4.py
+++ b/tests/test_metrics_v4.py
@@ -6,6 +6,8 @@ from pathlib import Path
 sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
 
 import numpy as np
+from typing import Any
+from numpy.typing import NDArray
 
 import core.por_v4 as por_v4
 import core.delta_e_v4 as delta_e_v4  # noqa: F401
@@ -19,7 +21,7 @@ sci = importlib.import_module("core.sci")
 
 
 class DummyEmbedder:
-    def encode(self, text: str) -> np.ndarray:
+    def encode(self, text: str) -> NDArray[Any]:
         if text == "hello":
             return np.array([1.0, 0.0])
         if text == "hello world":

--- a/tests/test_metrics_v4.py
+++ b/tests/test_metrics_v4.py
@@ -1,0 +1,66 @@
+import unittest
+from unittest.mock import patch
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+import numpy as np
+
+import core.por_v4 as por_v4
+import core.delta_e_v4 as delta_e_v4  # noqa: F401
+import core.grv_v4 as grv_v4  # noqa: F401
+import core.sci as sci  # noqa: F401
+import importlib
+
+delta_e_v4 = importlib.import_module("core.delta_e_v4")
+grv_v4 = importlib.import_module("core.grv_v4")
+sci = importlib.import_module("core.sci")
+
+
+class DummyEmbedder:
+    def encode(self, text: str) -> np.ndarray:
+        if text == "hello":
+            return np.array([1.0, 0.0])
+        if text == "hello world":
+            return np.array([0.62, np.sqrt(1 - 0.62 ** 2)])
+        n = float(len(text.split()))
+        return np.array([n, 0.0])
+
+
+class TestMetricsV4(unittest.TestCase):
+    @patch("core.por_v4._get_embedder", return_value=DummyEmbedder())
+    def test_por_score(self, mock_emb) -> None:
+        val = por_v4.score("a", "b")
+        self.assertGreaterEqual(val, 0.0)
+        self.assertLessEqual(val, 1.0)
+
+    @patch("core.delta_e_v4._get_embedder", return_value=DummyEmbedder())
+    def test_delta_e_v4(self, mock_emb) -> None:
+        val = delta_e_v4.delta_e("hello", "hello world")
+        self.assertAlmostEqual(val, 0.375, places=3)
+
+    def test_grv_v4(self) -> None:
+        score_val = grv_v4.grv("alpha beta beta gamma")
+        self.assertGreater(score_val, 0.0)
+        self.assertLessEqual(score_val, 1.0)
+        long_text = " ".join(["word"] * 60)
+        long_val = grv_v4.grv(long_text)
+        self.assertGreater(long_val, 0.0)
+        self.assertLessEqual(long_val, 1.0)
+        rep_text = ("a " * 30 + "b " * 30).strip()
+        self.assertLess(grv_v4.grv(rep_text), grv_v4.grv("a b"))
+        self.assertLess(
+            grv_v4._pmi_score(rep_text.split()),
+            grv_v4._pmi_score("a b".split()),
+        )
+
+    def test_sci(self) -> None:
+        sci.reset_state()
+        v1 = sci.sci(0.0, 0.0, 0.0)
+        v2 = sci.sci(1.0, 1.0, 1.0)
+        self.assertNotEqual(v1, v2)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- compute PMI using pair frequencies over 50-token windows
- adjust GRV test to expect reduced PMI on repeated tokens

## Testing
- `pytest -q tests/test_metrics_v4.py`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6859051690448330a47479b83c288e06