### PR TITLE
refactor: SCI v4 のクラス化＆パッケージ移動

### DIFF
--- a/core/__init__.py
+++ b/core/__init__.py
@@ -3,7 +3,7 @@ from .grv import grv_score
 from .delta_e_v4 import score as delta_e_v4, set_params as set_deltae_params
 from .grv_v4 import score as grv_v4, set_params as set_grv_params
 from .por_v4 import calc_por_v4 as por_score, set_params as set_por_params
-from .sci import score as sci, set_weights as set_sci_weights
+from .sci import sci, reset_state as reset_sci_state
 from .history import evaluate_record, GOOD, OKAY, BAD
 
 __all__ = [
@@ -20,5 +20,5 @@ __all__ = [
     "set_deltae_params",
     "set_grv_params",
     "set_por_params",
-    "set_sci_weights",
+    "reset_sci_state",
 ]

--- a/core/sci.py
+++ b/core/sci.py
@@ -1,73 +1,20 @@
-"""Semantic Consistency Index."""
+"""Legacy wrapper for Self-Coherence Index v4."""
 
 from __future__ import annotations
 
-import numpy as np
-from typing import Iterable, Sequence, Any
-from numpy.typing import NDArray
+from ugh3_metrics.metrics import SciV4
 
-DEFAULT_WEIGHTS: NDArray[Any] = np.array([0.4, 0.45, 0.15])
-DEFAULT_ALPHA: float = 0.3
-_STATE: float | None = None
+_SCI = SciV4()
 
 
-def set_weights(weights: Sequence[float], alpha: float | None = None) -> None:
-    """Set global weights and EMA parameter."""
-    global DEFAULT_WEIGHTS, DEFAULT_ALPHA
-    arr = np.asarray(list(weights), dtype=float)
-    if arr.size != 3:
-        raise ValueError("weights must have length 3")
-    DEFAULT_WEIGHTS = arr
-    if alpha is not None:
-        DEFAULT_ALPHA = float(alpha)
+def sci(val: float) -> float:
+    """Backward-compatible entry point."""
+    return _SCI.score(val, "")
 
 
 def reset_state() -> None:
     """Reset internal EMA state."""
-    global _STATE
-    _STATE = None
+    _SCI.reset_state()
 
 
-def sci(
-    por: float,
-    delta_e: float,
-    grv: float,
-    *,
-    weights: Iterable[float] | None = None,
-    alpha: float | None = None,
-) -> float:
-    """Return EMA of weighted metrics.
-
-    Parameters
-    ----------
-    por, delta_e, grv : float
-        Input metrics in the range 0.0 to 1.0.
-    weights : Iterable[float], optional
-        Custom weights ``(w1, w2, w3)``.
-
-    Returns
-    -------
-    float
-        Weighted score between 0.0 and 1.0.
-    """
-    w = (
-        np.asarray(list(weights), dtype=float)
-        if weights is not None
-        else DEFAULT_WEIGHTS
-    )
-    if w.size != 3:
-        raise ValueError("weights must have length 3")
-    w = w / w.sum()
-    vals = np.array([por, 1.0 - delta_e, grv], dtype=float)
-    x = float(np.dot(w, vals))
-    a = DEFAULT_ALPHA if alpha is None else float(alpha)
-    global _STATE
-    _STATE = x if _STATE is None else a * x + (1 - a) * _STATE
-    return float(_STATE)
-
-
-# backward compatibility
-score = sci
-
-
-__all__ = ["sci", "score", "set_weights", "reset_state"]
+__all__ = ["SciV4", "sci", "reset_state"]

--- a/tests/test_metrics_v4.py
+++ b/tests/test_metrics_v4.py
@@ -24,14 +24,5 @@ class DummyEmbedder:
         return np.array([n, 0.0])
 
 
-class TestMetricsV4(unittest.TestCase):
-
-    def test_sci(self) -> None:
-        sci.reset_state()
-        v1 = sci.sci(0.0, 0.0, 0.0)
-        v2 = sci.sci(1.0, 1.0, 1.0)
-        self.assertNotEqual(v1, v2)
-
-
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_sci_v4.py
+++ b/tests/test_sci_v4.py
@@ -1,0 +1,26 @@
+import unittest
+from pathlib import Path
+import sys
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+from ugh3_metrics.metrics import SciV4, sci, reset_state
+
+
+class TestSciV4(unittest.TestCase):
+    def test_stateful_transition_and_wrapper(self) -> None:
+        reset_state()
+        v1 = sci(0.0)
+        v2 = sci(1.0)
+        self.assertNotEqual(v1, v2)
+
+        metric = SciV4()
+        metric.reset_state()
+        w1 = metric.score(0.0, "")
+        w2 = metric.score(1.0, "")
+        self.assertEqual(v1, w1)
+        self.assertEqual(v2, w2)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/ugh3_metrics/metrics/__init__.py
+++ b/ugh3_metrics/metrics/__init__.py
@@ -1,7 +1,9 @@
 from .por_v4 import PorV4, calc_por_v4
 from .deltae_v4 import DeltaEV4, calc_deltae_v4
 from .grv_v4 import GrvV4, calc_grv_v4
+from .sci_v4 import SciV4, sci, reset_state
 
 __all__ = ["PorV4", "calc_por_v4"]
 __all__.extend(["DeltaEV4", "calc_deltae_v4"])
 __all__.extend(["GrvV4", "calc_grv_v4"])
+__all__.extend(["SciV4", "sci", "reset_state"])

--- a/ugh3_metrics/metrics/sci_v4.py
+++ b/ugh3_metrics/metrics/sci_v4.py
@@ -1,0 +1,49 @@
+from __future__ import annotations
+
+from ..metrics.base import BaseMetric
+from typing import cast
+import numpy as np
+
+
+class SciV4(BaseMetric):
+    """Self-Coherence Index v4 using exponential moving average."""
+
+    DEFAULT_ALPHA: float = 0.6
+
+    def __init__(self, *, alpha: float | None = None) -> None:
+        self._alpha = float(alpha) if alpha is not None else self.DEFAULT_ALPHA
+        self._state: float | None = None
+
+    # --- public API ---
+    def reset_state(self) -> None:
+        """Reset internal EMA state."""
+        self._state = None
+
+    def score(self, a: str | float, b: str) -> float:
+        """Update EMA with value ``a`` and return normalized coherence."""
+        del b
+        x = float(a)
+        if self._state is None:
+            self._state = x
+        else:
+            self._state = self._alpha * x + (1 - self._alpha) * self._state
+        return float(np.clip(self._state, 0.0, 1.0))
+
+    def set_params(self, **kw: object) -> None:
+        if "alpha" in kw:
+            self._alpha = float(cast(float, kw["alpha"]))
+
+
+_SCI = SciV4()
+
+def sci(val: float) -> float:
+    """Module-level wrapper for backward compatibility."""
+    return _SCI.score(val, "")
+
+
+def reset_state() -> None:
+    """Reset global metric state."""
+    _SCI.reset_state()
+
+
+__all__ = ["SciV4", "sci", "reset_state"]


### PR DESCRIPTION
## Summary
- implement `SciV4` class under `ugh3_metrics/metrics`
- expose wrapper functions `sci` and `reset_state`
- update legacy module `core.sci` to use new class
- update package exports
- add dedicated tests for `SciV4`
- remove old SCI test from `test_metrics_v4`

## Testing
- `python -m pytest -q`
- `python -m mypy .`


------
https://chatgpt.com/codex/tasks/task_e_685a2249a14c8330a823d1fd8ec81a0a