### PR TITLE
Add ruff config

### DIFF
--- a/.ruff.toml
+++ b/.ruff.toml
@@ -1,0 +1,7 @@
+[tool.ruff]
+target-version = "py39"
+select = ["F", "E"]
+ignore = [
+  "F401",  # unused import
+  "E402",  # module import not at top of file
+]


### PR DESCRIPTION
## Summary
- add minimal `.ruff.toml` with Python 3.9 target and ignore F401/E402

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685ac6df3a80833098dc52a59936074f