### PR TITLE
Update ruff config to ignore long lines/imports

### DIFF
--- a/.ruff.toml
+++ b/.ruff.toml
@@ -1,5 +1,11 @@
 target-version = "py39"
+line-length = 120
 
 [lint]
 select = ["F", "E"]
-ignore = ["F401", "E402"]
+ignore = [
+  "F401",
+  "E402",
+  "E501",
+  "E401",
+]


### PR DESCRIPTION
## Summary
- update `.ruff.toml` to ignore E501 and E401 and set line-length to 120

## Testing
- `python -m pytest -q`
- `./setup.sh` *(fails: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_685ae4e9f1248330ba1db14a5b2e1ffa