### PR TITLE
Remove F841 ignore and fix unused variable

### DIFF
--- a/.ruff.toml
+++ b/.ruff.toml
@@ -7,6 +7,6 @@ ignore = [
   "F401",
   "E402",
   "E501",
-  "E401",
-  "F841"
+  "E401"
+  # F841 removed to enable unused variable detection
 ]

--- a/scripts/review_processor.py
+++ b/scripts/review_processor.py
@@ -22,11 +22,6 @@ PATTERNS = {
 
 def github_api_request(url: str, token: str) -> Optional[Dict[str, Any]]:
     """Send a GET request to the GitHub API and return JSON data."""
-    headers = {
-        "Authorization": f"token {token}",
-        "Accept": "application/vnd.github.v3+json",
-        "User-Agent": "ai-review-response",
-    }
     try:
         req = subprocess.run(
             ["curl", "-s", "-H", f"Authorization: token {token}", url],


### PR DESCRIPTION
## Summary
- enable Ruff check for unused variables by removing F841 from `.ruff.toml`
- clean up an unused variable in `scripts/review_processor.py`

## Testing
- `python -m ruff check .`
- `python -m pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685c095fcce883308e9dc4ed0c000a75