### PR TITLE
Enable Ruff E401 and split multi‑imports

### DIFF
--- a/.ruff.toml
+++ b/.ruff.toml
@@ -6,7 +6,6 @@ select = ["F", "E"]
 ignore = [
   "F401",
   "E402",
-  "E501",
-  "E401"
+  "E501"
   # F841 removed to enable unused variable detection
 ]

--- a/tests/test_anomalies.py
+++ b/tests/test_anomalies.py
@@ -1,4 +1,5 @@
-import sys, os
+import sys
+import os
 sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
 
 import unittest

--- a/tests/test_grv_gain.py
+++ b/tests/test_grv_gain.py
@@ -1,4 +1,5 @@
-import sys, os
+import sys
+import os
 sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
 
 import unittest

--- a/tests/test_metrics.py
+++ b/tests/test_metrics.py
@@ -1,4 +1,5 @@
-import sys, os
+import sys
+import os
 sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
 
 import unittest

--- a/tests/test_smoke.py
+++ b/tests/test_smoke.py
@@ -1,4 +1,5 @@
-import sys, os
+import sys
+import os
 sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
 
 def test_imports() -> None:


### PR DESCRIPTION
## Summary
- clean up imports in tests
- enforce Ruff's E401 rule

## Testing
- `python -m ruff check .`
- `python -m pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685c1418996083308d458dcd083e7fb9