### PR TITLE
Fix E402 imports

### DIFF
--- a/examples/phase_map_heatmap.py
+++ b/examples/phase_map_heatmap.py
@@ -1,11 +1,11 @@
-from __future__ import annotations
-
 """Generate a simple phase map heatmap for PoR scores.
 
 This script creates a dummy history of timestamped PoR scores and
 plots them using ``matplotlib.imshow``. The resulting image is saved to
 ``images/phase_map.png`` for inclusion in the project README.
 """
+
+from __future__ import annotations
 
 from dataclasses import dataclass
 import argparse

--- a/facade/collector.py
+++ b/facade/collector.py
@@ -13,19 +13,19 @@ from __future__ import annotations
 
 import argparse
 import csv
-import time
 import itertools
-import random
-from dataclasses import dataclass, asdict, field
-
-from pathlib import Path
-from typing import Any, Dict, List, Tuple, Optional
 import os
+import random
 import sys
+import time
+from dataclasses import asdict, dataclass, field
+from pathlib import Path
+from typing import Any, Dict, List, Optional, Tuple
+
+from facade.trigger import por_trigger
+from ugh3_metrics.metrics import DeltaEV4, GrvV4, PorV4
 
 _EMBEDDER: Any | None = None
-
-from ugh3_metrics.metrics import PorV4, DeltaEV4, GrvV4
 
 STOPWORDS: set[str] = set()
 _stop_path = Path(__file__).resolve().parent.parent / "data" / "jp_stop.txt"
@@ -34,8 +34,6 @@ try:
         STOPWORDS.update(word.strip() for word in sfh if word.strip())
 except Exception:  # pragma: no cover - optional dependency
     pass
-
-from facade.trigger import por_trigger
 
 DOMAINS: list[str] = ["general", "creative", "technical", "specialized"]
 DIFFICULTIES: list[int] = [1, 2, 3, 4, 5]

--- a/tests/test_examples.py
+++ b/tests/test_examples.py
@@ -1,4 +1,6 @@
 import matplotlib
+from pathlib import Path
+
 matplotlib.use('Agg')
 
 def test_import_example_modules() -> None:
@@ -6,9 +8,6 @@ def test_import_example_modules() -> None:
     import facade.collector
     import secl.qa_cycle
     import core.history
-
-
-from pathlib import Path
 
 
 def test_scripts_run(tmp_path: Path) -> None:

--- a/tests/warm_cache_test.py
+++ b/tests/warm_cache_test.py
@@ -16,7 +16,7 @@ code = 'def download_model(name):\n    pass\n'
 
 sys.path.insert(0, str(FAKE_DIR))
 
-import warm_cache
+import warm_cache  # noqa: E402
 
 
 def test_cli_help() -> None:


### PR DESCRIPTION
## Summary
- move docstring before `__future__` import
- reorder imports in `facade/collector.py`
- move `Path` import to top in tests
- ignore delayed import with `# noqa: E402`

## Testing
- `python -m ruff check . --select E402 --output-format=concise`
- `python -m pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685c1b649c1483308af6cee0a1c5ea2a