### PR TITLE
Fix: alphabetize imports in example

### DIFF
--- a/examples/phase_map_heatmap.py
+++ b/examples/phase_map_heatmap.py
@@ -7,8 +7,8 @@ plots them using ``matplotlib.imshow``. The resulting image is saved to
 
 from __future__ import annotations
 
-from dataclasses import dataclass
 import argparse
+from dataclasses import dataclass
 import random
 import time
 from typing import List


### PR DESCRIPTION
## Summary
- sort stdlib imports in `phase_map_heatmap.py`

## Testing
- `python -m ruff check examples/phase_map_heatmap.py`
- `python -m pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_685c2f93a3c88330a24090613d21b4f7