### PR TITLE
Enable Ruff E402 and tidy imports

### DIFF
--- a/.ruff.toml
+++ b/.ruff.toml
@@ -5,7 +5,6 @@ line-length = 120
 select = ["F", "E"]
 ignore = [
   "F401",
-  "E402",
   "E501"
   # F841 removed to enable unused variable detection
 ]

--- a/tests/test_grv_gain.py
+++ b/tests/test_grv_gain.py
@@ -1,9 +1,10 @@
-import sys
 import os
-sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
-
+import sys
 import unittest
-from secl.qa_cycle import simulate_grv_gain_with_jump, simulate_grv_gain_with_external_info
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+
+from secl.qa_cycle import simulate_grv_gain_with_jump, simulate_grv_gain_with_external_info  # noqa: E402
 
 class TestGrvGain(unittest.TestCase):
     def test_gain_returns_float(self) -> None:

--- a/tests/test_metrics.py
+++ b/tests/test_metrics.py
@@ -1,10 +1,10 @@
-import sys
 import os
-sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
-
+import sys
 import unittest
 
-from secl.qa_cycle import novelty_score, is_duplicate_question, HistoryEntry
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+
+from secl.qa_cycle import novelty_score, is_duplicate_question, HistoryEntry  # noqa: E402
 
 
 class TestMetrics(unittest.TestCase):

--- a/warm_cache.py
+++ b/warm_cache.py
@@ -1,5 +1,8 @@
 # mypy: ignore-errors
 
+import argparse
+from typing import List
+
 try:
     from comet.download_utils import download_model  # COMET < 2.0
 except ModuleNotFoundError:  # pragma: no cover
@@ -10,9 +13,6 @@ except ModuleNotFoundError:  # pragma: no cover
             "サポートされていない COMET 版です。"
             "対応バージョンをインストールするか、import ロジックを更新してください。"
         ) from exc
-
-import argparse
-from typing import List
 
 def download_models(models: List[str]) -> None:
     for model in models:


### PR DESCRIPTION
## Summary
- move imports to the top of the file for remaining modules
- enable Ruff's E402 rule

## Testing
- `python -m ruff check .`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685c3c2e3e2c8330b7e36b8ca869e59f