### PR TITLE
Fix ΔE==0 issue in DeltaEV4

### DIFF
--- a/tests/test_deltae_hash.py
+++ b/tests/test_deltae_hash.py
@@ -1,0 +1,6 @@
+from ugh3_metrics.metrics import DeltaEV4
+
+def test_deltae_hash_fallback() -> None:
+    m = DeltaEV4()
+    assert m.score("abc", "abd") > 0.0
+    assert m.score("", "") == 0.0

--- a/tests/test_deltae_zero.py
+++ b/tests/test_deltae_zero.py
@@ -1,0 +1,5 @@
+from ugh3_metrics.metrics import DeltaEV4
+
+def test_deltae_nonzero() -> None:
+    m = DeltaEV4()
+    assert m.score("abc", "abd") > 0.0


### PR DESCRIPTION
## Summary
- ensure DeltaEV4 uses a deterministic but non-zero MD5-based embedder when transformers are missing
- add fallback scoring logic using SequenceMatcher for zero-vector cases
- support embedder outputs that are not NumPy arrays
- add regression test for zero-vector fallback

## Testing
- `python -m ruff check .`
- `python -m pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_685d0aa2aa348330b9d3a952aee80914