### PR TITLE
Implement cosine-based DeltaEV4

### DIFF
--- a/tests/test_deltae_v4_cosvec.py
+++ b/tests/test_deltae_v4_cosvec.py
@@ -1,0 +1,14 @@
+from ugh3_metrics.metrics.deltae_v4 import DeltaEV4
+import numpy as np
+
+
+def test_score_cosvec() -> None:
+    a = "hello"
+    b = "world"
+    metric = DeltaEV4()
+    val = metric.score(a, b)
+    v1 = np.asarray([len(a), hash(a) % 13], dtype=float)
+    v2 = np.asarray([len(b), hash(b) % 13], dtype=float)
+    cos = float(np.dot(v1, v2) / (np.linalg.norm(v1) * np.linalg.norm(v2)))
+    expected = round(1.0 - cos, 3)
+    assert val == expected

--- a/ugh3_metrics/metrics/deltae_v4.py
+++ b/ugh3_metrics/metrics/deltae_v4.py
@@ -1,14 +1,19 @@
+import numpy as np
+
+
 class DeltaEV4:  # noqa: D101
     """Stub metric that always returns 0.0 (safety fence)."""
 
     def score(self, a: str, b: str) -> float:  # noqa: D401
         """Return |len(a)-len(b)| 正規化値 (0-1)。"""
-        import math
-
-        if a == b:
+        v1 = np.asarray([len(a), hash(a) % 13], dtype=float)
+        v2 = np.asarray([len(b), hash(b) % 13], dtype=float)
+        # どちらかがゼロベクトルの場合は距離を 1.0 とする
+        if not np.linalg.norm(v1) or not np.linalg.norm(v2):
+            return 1.0
+        if np.allclose(v1, v2):
             return 0.0
-        diff = abs(len(a) - len(b))
-        denom = max(len(a), len(b))
-        return round(diff / denom, 3)
+        cos = float(np.dot(v1, v2) / (np.linalg.norm(v1) * np.linalg.norm(v2)))
+        return round(1.0 - cos, 3)
 
 __all__: list[str] = ["DeltaEV4"]


### PR DESCRIPTION
## Summary
- extend DeltaEV4 metric to use 2D vectors (length and hash) and return cosine distance
- avoid cosine distance on zero vectors
- move numpy import to module level and remove unused math import
- add regression test for new cosine-distance behaviour

## Testing
- `python -m pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685e8d59344c8330980c93547dc3a6eb