### PR TITLE
Fix embedder typing and cleanup docstring

### DIFF
--- a/tests/test_deltae_v4_setparams.py
+++ b/tests/test_deltae_v4_setparams.py
@@ -1,0 +1,12 @@
+from ugh3_metrics.metrics.deltae_v4 import DeltaEV4
+
+
+class DummyEmb:
+    def encode(self, text: str) -> list[float]:
+        return [1.0, 0.0]
+
+
+def test_set_params_embedder() -> None:
+    metric = DeltaEV4()
+    metric.set_params(embedder=DummyEmb())
+    assert metric.score("a", "b") == 0.0

--- a/ugh3_metrics/metrics/deltae_v4.py
+++ b/ugh3_metrics/metrics/deltae_v4.py
@@ -1,13 +1,26 @@
+from typing import Protocol
+
 import numpy as np
 
 
+class _EmbedderProto(Protocol):
+    def encode(self, text: str) -> list[float]:
+        """Return an embedding for the given text."""
+
+
 class DeltaEV4:  # noqa: D101
-    """Stub metric that always returns 0.0 (safety fence)."""
+    """Stub metric: length+hash 2‐D コサイン距離を返す暫定実装."""
+
+    _embedder: _EmbedderProto | None = None  # set_params で動的に上書き
 
     def score(self, a: str, b: str) -> float:  # noqa: D401
         """Return |len(a)-len(b)| 正規化値 (0-1)。"""
-        v1 = np.asarray([len(a), hash(a) % 13], dtype=float)
-        v2 = np.asarray([len(b), hash(b) % 13], dtype=float)
+        if self._embedder is not None:
+            v1 = np.asarray(self._embedder.encode(a), dtype=float)
+            v2 = np.asarray(self._embedder.encode(b), dtype=float)
+        else:
+            v1 = np.asarray([len(a), hash(a) % 13], dtype=float)
+            v2 = np.asarray([len(b), hash(b) % 13], dtype=float)
         # どちらかがゼロベクトルの場合は距離を 1.0 とする
         if not np.linalg.norm(v1) or not np.linalg.norm(v2):
             return 1.0
@@ -15,5 +28,9 @@ class DeltaEV4:  # noqa: D101
             return 0.0
         cos = float(np.dot(v1, v2) / (np.linalg.norm(v1) * np.linalg.norm(v2)))
         return round(1.0 - cos, 3)
+
+    def set_params(self, *, embedder: _EmbedderProto | None = None) -> None:
+        if embedder is not None:
+            self._embedder = embedder  # 動的差し替え
 
 __all__: list[str] = ["DeltaEV4"]


### PR DESCRIPTION
## Summary
- remove duplicate docstring from `DeltaEV4`
- allow dynamic embedder injection via typed `_embedder`
- update dummy embedder test helper with return type
- tweak docstring to use non-breaking hyphen
- ensure a single blank line precedes `DeltaEV4` for PEP 8
- refine embedder typing using a protocol

## Testing
- `ruff .`
- `mypy`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_685f08cdfbe483308349c5f0665f70c0