### PR TITLE
Fix zero vector fallback in DeltaEV4

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,6 +108,12 @@ from core.grv import grv_score
 
 <!-- AUTO SECTION END -->
 
+### Reference Metrics
+PorV4, DeltaEV4, GrvV4, and SciV4 are provided as reference implementations
+under `ugh3_metrics.metrics`. Integration tests in `tests/` cover these
+modules; `tests/test_deltae_v4_setparams.py` verifies `DeltaEV4` using a dummy
+embedder.
+
 ### Visualization Utilities / 可視化用ユーティリティ
 
 `phase_map_heatmap.py` ではメトリクス履歴をヒートマップとして描画します。

--- a/tests/test_deltae_v4_fallback.py
+++ b/tests/test_deltae_v4_fallback.py
@@ -1,0 +1,13 @@
+from ugh3_metrics.metrics.deltae_v4 import DeltaEV4
+import numpy as np
+
+
+class ZeroEmb:
+    def encode(self, _: str):  # noqa: D401
+        return np.zeros(2)
+
+
+def test_zero_vector_fallback() -> None:
+    m = DeltaEV4()
+    m.set_params(embedder=ZeroEmb())
+    assert m.score("abc", "abd") > 0.0 and m.score("same", "same") == 0.0


### PR DESCRIPTION
## Summary
- fallback to `SequenceMatcher` when either embedding vector is zero
- add unit test for zero-vector fallback
- ensure two blank lines before `_EmbedderProto`
- mention reference metrics in README
- document fallback behavior in the `DeltaEV4` docstring

## Testing
- `ruff check .`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68634932e3148330883500f3bc782b92