### PR TITLE
Add dataset recalculation workflow

### DIFF
--- a/.github/workflows/recalc_dataset.yml
+++ b/.github/workflows/recalc_dataset.yml
@@ -1,0 +1,35 @@
+name: Recalculate metrics
+
+on:
+  workflow_dispatch:
+  push:
+    branches: [ main, master ]
+    paths:
+      - datasets/current.csv
+      - scripts/recalc_scores_v4.py
+
+jobs:
+  recalc:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+      - name: Install package
+        run: |
+          python -m pip install --upgrade pip
+          python -m pip install . pandas pyarrow
+      - name: Recalculate PoR/ΔE v4
+        env:
+          SENTENCE_TRANSFORMERS_HOME: ${{ github.workspace }}/.cache/st
+        run: |
+          python scripts/recalc_scores_v4.py \
+            --infile  datasets/current.csv \
+            --outfile datasets/current_recalc.parquet
+      - name: Upload artifact
+        uses: actions/upload-artifact@v3
+        with:
+          name: recalculated-dataset
+          path: datasets/current_recalc.parquet

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,8 @@
+all: test
+
+# ----------------------------------------------------------
+# データセット再計算（ローカル用）
+# 使い方: `make recalc IN=data/old.csv OUT=data/new.parquet`
+# ----------------------------------------------------------
+recalc:
+	python scripts/recalc_scores_v4.py --infile $(IN) --outfile $(OUT)


### PR DESCRIPTION
## Summary
- add a workflow to recompute metrics when the dataset or scoring script changes
- add a Makefile with a `recalc` target for local runs

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6866630d5e50833089f61d635d6bbd30