### PR TITLE
Add joblib dependency to workflow installs

### DIFF
--- a/.github/workflows/auto-por-daily.yml
+++ b/.github/workflows/auto-por-daily.yml
@@ -28,7 +28,7 @@ jobs:
 
       - name: Install deps
         run: |
-          pip install -r requirements.txt
+          pip install -r requirements.txt joblib
           # 追加: パッケージを editable でインストール
           pip install -e .
       - name: Warm cache – COMET-Kiwi

--- a/.github/workflows/build-dataset.yml
+++ b/.github/workflows/build-dataset.yml
@@ -29,7 +29,7 @@ jobs:
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
-          pip install -r requirements.txt
+          pip install -r requirements.txt joblib
       - name: Scrape tech docs
         run: python scripts/scrape_docs.py --out tech.jsonl
       - name: Generate dialogs

--- a/.github/workflows/recalc_dataset.yml
+++ b/.github/workflows/recalc_dataset.yml
@@ -20,7 +20,7 @@ jobs:
       - name: Install package
         run: |
           python -m pip install --upgrade pip
-          python -m pip install . pandas pyarrow tqdm
+          python -m pip install . pandas pyarrow tqdm joblib
       - name: Recalculate PoR/ΔE v4
         env:
           SENTENCE_TRANSFORMERS_HOME: ${{ github.workspace }}/.cache/st


### PR DESCRIPTION
## Summary
- ensure joblib is installed in dataset-related workflows

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686766f47e408330a7d4e7c6b13fa335