### PR TITLE
Add ST_CACHE env and maintainer info

### DIFF
--- a/.github/workflows/auto-collect.yml
+++ b/.github/workflows/auto-collect.yml
@@ -25,9 +25,10 @@ jobs:
           python -m pip install --upgrade pip
           pip install -r requirements.txt
       - name: Run collector
-        env:
-          OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
-          PYTHONPATH: ${{ github.workspace }}
+      env:
+        OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
+        ST_CACHE: ${{ github.workspace }}/.cache/st
+        PYTHONPATH: ${{ github.workspace }}
         id: collect
         run: |
           python facade/collector.py --auto -n 50 --q-provider openai --ai-provider openai --quiet --summary

--- a/.github/workflows/auto-por-daily.yml
+++ b/.github/workflows/auto-por-daily.yml
@@ -11,6 +11,7 @@ jobs:
     timeout-minutes: 60   # BLEURT モデルDLの余裕確保
     env:
       OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
+      ST_CACHE: ${{ github.workspace }}/.cache/st
       # ルートを PYTHONPATH に追加して utils パッケージを解決
       PYTHONPATH: ${{ github.workspace }}
     steps:

--- a/.github/workflows/build-dataset.yml
+++ b/.github/workflows/build-dataset.yml
@@ -35,9 +35,10 @@ jobs:
       - name: Scrape tech docs
         run: python scripts/scrape_docs.py --out tech.jsonl
       - name: Generate dialogs
-        env:
-          OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
-          PYTHONPATH: ${{ github.workspace }}
+      env:
+        OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
+        ST_CACHE: ${{ github.workspace }}/.cache/st
+        PYTHONPATH: ${{ github.workspace }}
         run: |
           # 1) Q&A 生成 → dialogs.csv を runs/<exp_id>/ に保存
           python facade/collector.py --auto -n 50 \

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,6 +14,9 @@ permissions:
 jobs:
   test:
     runs-on: ubuntu-latest
+    env:
+      PYTHONPATH: ${{ github.workspace }}
+      ST_CACHE: ${{ github.workspace }}/.cache/st
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-python@v5

--- a/.github/workflows/pr-to-issue-sync.yml
+++ b/.github/workflows/pr-to-issue-sync.yml
@@ -8,6 +8,9 @@ on:
 jobs:
   sync_issue:
     runs-on: ubuntu-latest
+    env:
+      PYTHONPATH: ${{ github.workspace }}
+      ST_CACHE: ${{ github.workspace }}/.cache/st
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4

--- a/.github/workflows/recalc_dataset.yml
+++ b/.github/workflows/recalc_dataset.yml
@@ -24,6 +24,8 @@ jobs:
           pip install -e .
       - name: Recalculate PoR/ΔE v4
         env:
+          PYTHONPATH: ${{ github.workspace }}
+          ST_CACHE: ${{ github.workspace }}/.cache/st
           SENTENCE_TRANSFORMERS_HOME: ${{ github.workspace }}/.cache/st
         run: |
           python scripts/recalc_scores_v4.py \

--- a/.github/workflows/secret-smoke.yml
+++ b/.github/workflows/secret-smoke.yml
@@ -4,6 +4,9 @@ on: workflow_dispatch
 jobs:
   test:
     runs-on: ubuntu-latest
+    env:
+      PYTHONPATH: ${{ github.workspace }}
+      ST_CACHE: ${{ github.workspace }}/.cache/st
     steps:
       - name: Check secret
         run: echo "KEY=${{ secrets.OPENAI_API_KEY }}"

--- a/.github/workflows/typecheck.yml
+++ b/.github/workflows/typecheck.yml
@@ -9,6 +9,9 @@ on:
 jobs:
   mypy:
     runs-on: ubuntu-latest
+    env:
+      PYTHONPATH: ${{ github.workspace }}
+      ST_CACHE: ${{ github.workspace }}/.cache/st
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-python@v5

--- a/.github/workflows/unified-ai-issue-to-pr.yml
+++ b/.github/workflows/unified-ai-issue-to-pr.yml
@@ -12,6 +12,9 @@ permissions:
 jobs:
   generate:
     runs-on: ubuntu-latest
+    env:
+      PYTHONPATH: ${{ github.workspace }}
+      ST_CACHE: ${{ github.workspace }}/.cache/st
     steps:
       - name: Checkout
         uses: actions/checkout@v4

--- a/README.md
+++ b/README.md
@@ -225,6 +225,11 @@ python facade/collector.py --auto -n 10 --q-provider openai --ai-provider openai
 ## Contribution / コントリビュート
 改善提案やバグ報告はPull RequestまたはIssueでお願いします。
 
+## Maintainers
+This project is primarily maintained by [Yuu6798](https://github.com/Yuu6798).
+Maintainers should set the `ST_CACHE` environment variable to a persistent
+cache directory to avoid re-downloading models during CI runs.
+
 ## License / ライセンス
 MIT License
 


### PR DESCRIPTION
## Summary
- set `PYTHONPATH` and `ST_CACHE` for all CI workflows
- document project maintainer responsibilities in the README

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6868015e80ec83308c85ab9a37c94c18