### PR TITLE
Add concurrency limit and extend push retries

### DIFF
--- a/.github/workflows/build-dataset.yml
+++ b/.github/workflows/build-dataset.yml
@@ -1,5 +1,12 @@
 name: Build Dataset
 
+########################################
+# A. 同時実行を 1 本に制限
+########################################
+concurrency:
+  group: build-dataset-main          # ← 任意のグループ名
+  cancel-in-progress: true           # 古い run をキャンセル
+
 on:
   workflow_dispatch:
     inputs:
@@ -86,13 +93,23 @@ jobs:
 
           git commit -m "Add dataset for $DATE"
 
-          # ---- push with a pull‑rebase guard ---------------------------------
-          # 1回目の push が拒否されたら pull --rebase して再 push
-          if ! git push origin HEAD:main; then
-            echo "Fast‑forward push rejected; rebasing onto origin/main..."
+          #########################################################
+          # B. push を最大 5 回リトライ
+          #########################################################
+          for i in 1 2 3 4 5; do
+            echo ">>> push attempt #$i ..."
+            if git push origin HEAD:main; then
+              echo "Push succeeded."
+              break
+            fi
+            echo "Push rejected – rebasing onto latest origin/main"
             git pull --rebase --autostash origin main
-            git push origin HEAD:main
-          fi
+            if [ "$i" = 5 ]; then
+              echo "Push failed after 5 attempts, aborting."
+              exit 1
+            fi
+            sleep 4
+          done
 
           echo "date=$DATE" >> "$GITHUB_OUTPUT"
 


### PR DESCRIPTION
## Summary
- ensure the dataset workflow only runs one instance at a time
- retry the dataset push up to five times before failing

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_686fb97b7e4c8330ae9a557d43df626d