### PR TITLE
Fix push retry logic in dataset workflow

### DIFF
--- a/.github/workflows/build-dataset.yml
+++ b/.github/workflows/build-dataset.yml
@@ -100,20 +100,25 @@ jobs:
           #######################################################################
           # ❸ push を最大５回までリトライ（--force-with-lease で競合安全に上書き）
           #######################################################################
-          for i in 1 2 3 4 5; do
-            echo ">>> push attempt #$i ..."
-            if git push --force-with-lease origin HEAD:main; then
-              echo "Push succeeded."
-              break
-            fi
-            echo "Push rejected – rebasing onto latest origin/main, retrying..."
-            git pull --rebase --autostash origin main
-            sleep 4
-            if [ "$i" = 5 ]; then
-              echo "Push failed after 5 attempts, aborting."
-              exit 1
-            fi
-          done
+            # set -e を一時解除して「push 失敗→pull --rebase→sleep」を繰り返せるように
+            set +e
+            for i in 1 2 3 4 5; do
+              echo ">>> push attempt #$i ..."
+              git push --force-with-lease origin HEAD:main
+              if [ $? -eq 0 ]; then
+                echo "Push succeeded."
+                break
+              fi
+              echo "Push rejected – rebasing onto latest origin/main, retrying..."
+              git pull --rebase --autostash origin main
+              sleep 4
+              if [ "$i" = 5 ]; then
+                echo "Push failed after 5 attempts, aborting." >&2
+                set -e     # 元に戻す
+                exit 1
+              fi
+            done
+            set -e         # 安全のため再度有効化
 
           echo "date=$DATE" >> "$GITHUB_OUTPUT"
 


### PR DESCRIPTION
## Summary
- update push retry block in `build-dataset.yml` to temporarily disable `set -e`
- use explicit exit-code check and re-enable `set -e`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6870a17937b88330bf43f3d847799e16