### PR TITLE
Fix dataset artifact path

### DIFF
--- a/.github/workflows/build-dataset.yml
+++ b/.github/workflows/build-dataset.yml
@@ -66,8 +66,8 @@ jobs:
       - name: Upload current.csv as artefact
         uses: actions/upload-artifact@v4
         with:
-          name: current-dataset-csv
-          path: datasets/current.csv
+          name: current-dataset-csv          # artefact 名は維持
+          path: current.csv                  # ファイル単体をアップロード
 
       - name: Commit dataset
         id: commit


### PR DESCRIPTION
## Summary
- adjust artifact upload path in `build-dataset.yml` so recalc job downloads
  into the expected directory

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68715387232c8330849e4f45a41a95dc