### PR TITLE
Fix scoring scripts to use answer_b field

### DIFF
--- a/scripts/auto_score.py
+++ b/scripts/auto_score.py
@@ -36,7 +36,7 @@ def main() -> None:
 
     df = pd.read_csv(args.input)
 
-    candidates = df["answer"].astype(str).tolist()
+    candidates = df["answer_b"].astype(str).tolist()
     references = df["question"].astype(str).tolist()
 
     # BERTScore

--- a/scripts/recalc_deltae.py
+++ b/scripts/recalc_deltae.py
@@ -37,9 +37,9 @@ def main() -> None:
 
     prev_answer: str | None = None
     for row in rows:
-        answer = row.get("answer", "")
-        row["delta_e_norm"] = f"{delta_e(prev_answer, answer):.3f}"
-        prev_answer = answer
+        answer_b = row.get("answer_b", "")
+        row["delta_e_norm"] = f"{delta_e(prev_answer, answer_b):.3f}"
+        prev_answer = answer_b
 
     with out_path.open("w", newline="", encoding="utf-8") as fh:
         writer = csv.DictWriter(fh, fieldnames=fieldnames)


### PR DESCRIPTION
## Summary
- update `auto_score.py` to read `answer_b`
- update `recalc_deltae.py` to use `answer_b`

## Testing
- `python -m pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6873c2a2ece48330a8e1370f2f2e417f