### PR TITLE
AUTO: fix until tests pass

### DIFF
--- a/core/history_entry.py
+++ b/core/history_entry.py
@@ -16,6 +16,14 @@ class HistoryEntry:
     grv: float
     domain: str
     difficulty: int
+    score: float = 0.0
+    spike: bool = False
+    external: bool = False
+    anomaly_por: bool = False
+    anomaly_delta_e: bool = False
+    anomaly_grv: bool = False
+    por_null: bool = False
+    score_threshold: float | None = None
     timestamp: float = field(default_factory=time.time)
 
 __all__ = ["HistoryEntry"]

--- a/core/history_entry.py
+++ b/core/history_entry.py
@@ -1,0 +1,21 @@
+from __future__ import annotations
+
+import time
+from dataclasses import dataclass, field
+
+
+@dataclass
+class HistoryEntry:
+    """Common history record for metric collection."""
+
+    question: str
+    answer_a: str
+    answer_b: str
+    por: float
+    delta_e: float
+    grv: float
+    domain: str
+    difficulty: int
+    timestamp: float = field(default_factory=time.time)
+
+__all__ = ["HistoryEntry"]

--- a/facade/collector.py
+++ b/facade/collector.py
@@ -432,6 +432,15 @@ def run_cycle(
                     "grv": grv,
                     "domain": domain,
                     "difficulty": difficulty,
+                    "timestamp": history[-1].timestamp,
+                    "score": history[-1].score,
+                    "spike": history[-1].spike,
+                    "external": history[-1].external,
+                    "anomaly_por": history[-1].anomaly_por,
+                    "anomaly_delta_e": history[-1].anomaly_delta_e,
+                    "anomaly_grv": history[-1].anomaly_grv,
+                    "por_null": history[-1].por_null,
+                    "score_threshold": history[-1].score_threshold,
                     "provider": provider,
                 }
                 with open(jsonl_path, "a", encoding="utf-8") as jfh:
@@ -450,6 +459,14 @@ def run_cycle(
             "domain",
             "difficulty",
             "timestamp",
+            "score",
+            "spike",
+            "external",
+            "anomaly_por",
+            "anomaly_delta_e",
+            "anomaly_grv",
+            "por_null",
+            "score_threshold",
         ]
         with open(output, "w", newline="", encoding="utf-8") as fh:
             writer = csv.DictWriter(fh, fieldnames=fields)

--- a/facade/collector.py
+++ b/facade/collector.py
@@ -18,11 +18,12 @@ import os
 import random
 import sys
 import time
-from dataclasses import asdict, dataclass, field
+from dataclasses import asdict
 from pathlib import Path
 from typing import Any, Dict, List, Tuple
 
 from ugh3_metrics.metrics import DeltaEV4, GrvV4, PorV4
+from core.history_entry import HistoryEntry
 
 _EMBEDDER: Any | None = None
 
@@ -331,18 +332,8 @@ def evaluate_metrics(por: float, delta_e_val: float, grv: float) -> Tuple[float,
 # ---------------------------------------------------------------------------
 
 
-@dataclass
-class HistoryEntry:
-    question: str
-    answer: str
-    por: float
-    delta_e: float
-    grv: float
-    domain: str
-    difficulty: int
-    timestamp: float = field(default_factory=time.time)
-
-
+# ``HistoryEntry`` is imported from :mod:`core.history_entry` for reuse across
+# modules.
 # --- 互換エイリアス ------------
 QARecord = HistoryEntry
 # --------------------------------
@@ -423,11 +414,23 @@ def run_cycle(
             print(f"【総合】{score:.3f} → {decision}")
 
         if adopted:
-            history.append(HistoryEntry(question, answer, por, de, grv, domain, difficulty))
+            history.append(
+                HistoryEntry(
+                    question,
+                    prev_answer or "",
+                    answer,
+                    por,
+                    de,
+                    grv,
+                    domain,
+                    difficulty,
+                )
+            )
             if jsonl_path is not None:
                 rec_dict = {
                     "question": question,
-                    "answer": answer,
+                    "answer_a": prev_answer or "",
+                    "answer_b": answer,
                     "por": por,
                     "delta_e": de,
                     "grv": grv,

--- a/secl/qa_cycle.py
+++ b/secl/qa_cycle.py
@@ -26,6 +26,8 @@ from typing import List, Tuple, Dict, Any
 from utils.config_loader import CONFIG
 from core.history_entry import HistoryEntry
 
+__all__ = ["HistoryEntry"]
+
 MAX_LOG_SIZE: int = CONFIG.get("MAX_LOG_SIZE", 10)
 BASE_SCORE_THRESHOLD: float = CONFIG.get("BASE_SCORE_THRESHOLD", 0.5)
 DELTA_E_WINDOW: int = CONFIG.get("DELTA_E_WINDOW", 5)

--- a/secl/qa_cycle.py
+++ b/secl/qa_cycle.py
@@ -174,10 +174,29 @@ def detect_spike(current_score: float, history_list: List[HistoryEntry]) -> bool
 def save_history_to_csv(path: Path, history_list: List[HistoryEntry]) -> None:
     try:
         with open(path, "w", newline="", encoding="utf-8") as fh:
-            writer = csv.DictWriter(fh, fieldnames=list(asdict(history_list[0]).keys()))
+            fields = [
+                "question",
+                "answer_a",
+                "answer_b",
+                "por",
+                "delta_e",
+                "grv",
+                "domain",
+                "difficulty",
+                "timestamp",
+                "score",
+                "spike",
+                "external",
+                "anomaly_por",
+                "anomaly_delta_e",
+                "anomaly_grv",
+                "por_null",
+                "score_threshold",
+            ]
+            writer = csv.DictWriter(fh, fieldnames=fields)
             writer.writeheader()
             for entry in history_list:
-                writer.writerow(asdict(entry))
+                writer.writerow({f: getattr(entry, f) for f in fields})
     except Exception as exc:
         print(f"[Error] Failed to save history: {exc}")
 

--- a/tests/test_anomalies.py
+++ b/tests/test_anomalies.py
@@ -27,7 +27,18 @@ class TestAnomalies(unittest.TestCase):
         self.assertFalse(detect_por_null("q", "ans", 1.0, 0.5))
 
     def test_backup_history(self) -> None:
-        hist = [HistoryEntry("q", "a", 0.1, 0.2, 0.3, False, False)]
+        hist = [
+            HistoryEntry(
+                question="q",
+                answer_a="",
+                answer_b="a",
+                por=0.1,
+                delta_e=0.2,
+                grv=0.3,
+                domain="test",
+                difficulty=1,
+            )
+        ]
         tmp_dir = Path("tests/tmp_bk")
         backup_history(tmp_dir, hist, "test")
         files = list(tmp_dir.glob("test_*.json"))

--- a/tests/test_anomalies.py
+++ b/tests/test_anomalies.py
@@ -8,9 +8,9 @@ from pathlib import Path
 from secl.qa_cycle import (
     check_metric_anomalies,
     detect_por_null,
-    HistoryEntry,
     backup_history,
 )
+from core.history_entry import HistoryEntry
 import json
 
 

--- a/tests/test_examples.py
+++ b/tests/test_examples.py
@@ -56,5 +56,13 @@ def test_run_cycle_generates_csv(tmp_path: Path) -> None:
         "domain",
         "difficulty",
         "timestamp",
+        "score",
+        "spike",
+        "external",
+        "anomaly_por",
+        "anomaly_delta_e",
+        "anomaly_grv",
+        "por_null",
+        "score_threshold",
     ]
     assert 1 <= len(rows) <= steps

--- a/tests/test_examples.py
+++ b/tests/test_examples.py
@@ -48,7 +48,8 @@ def test_run_cycle_generates_csv(tmp_path: Path) -> None:
 
     assert header == [
         "question",
-        "answer",
+        "answer_a",
+        "answer_b",
         "por",
         "delta_e",
         "grv",

--- a/tests/test_metrics.py
+++ b/tests/test_metrics.py
@@ -12,12 +12,34 @@ class TestMetrics(unittest.TestCase):
         self.assertEqual(novelty_score("q", []), 1.0)
 
     def test_novelty_similarity_penalty(self) -> None:
-        history = [HistoryEntry("hello world", "ans", 0, 0, 0, False, False)]
+        history = [
+            HistoryEntry(
+                question="hello world",
+                answer_a="",
+                answer_b="ans",
+                por=0.0,
+                delta_e=0.0,
+                grv=0.0,
+                domain="test",
+                difficulty=1,
+            )
+        ]
         result = novelty_score("hello world", history)
         self.assertLess(result, 1.0)
 
     def test_duplicate_detection(self) -> None:
-        history = [HistoryEntry("what is life?", "ans", 0, 0, 0, False, False)]
+        history = [
+            HistoryEntry(
+                question="what is life?",
+                answer_a="",
+                answer_b="ans",
+                por=0.0,
+                delta_e=0.0,
+                grv=0.0,
+                domain="test",
+                difficulty=1,
+            )
+        ]
         self.assertTrue(is_duplicate_question("what is life?", history))
         self.assertFalse(is_duplicate_question("another", history))
 

--- a/tests/test_metrics.py
+++ b/tests/test_metrics.py
@@ -4,7 +4,8 @@ import unittest
 
 sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
 
-from secl.qa_cycle import novelty_score, is_duplicate_question, HistoryEntry  # noqa: E402
+from secl.qa_cycle import novelty_score, is_duplicate_question  # noqa: E402
+from core.history_entry import HistoryEntry
 
 
 class TestMetrics(unittest.TestCase):


### PR DESCRIPTION
## Summary
- centralize `HistoryEntry` in `core.history_entry`
- update Q&A cycle to consume the shared dataclass
- remove obsolete compatibility property
- ensure vocab collection uses `answer_b`

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6874d42007548330aa77dad57a3a32a0