### PR TITLE
Fix collector workflow deps

### DIFF
--- a/.github/workflows/auto-collect.yml
+++ b/.github/workflows/auto-collect.yml
@@ -16,6 +16,20 @@ jobs:
         with:
           python-version: '3.11'
 
+      - name: Cache pip wheels
+        uses: actions/cache@v4
+        with:
+          path: ~/.cache/pip
+          key: pip-${{ runner.os }}-${{ hashFiles('requirements.txt') }}
+          restore-keys: |
+            pip-${{ runner.os }}-
+
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -r requirements.txt
+          pip install -e .
+
       # ------- Run collector & export run_dir -------
       - name: Run collector
         id: collect

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,6 +6,9 @@ authors = [
   { name = "Yuu6798", email = "kkoo6798@gmail.com" },
 ]
 requires-python = ">=3.8"
+dependencies = [
+  "numpy>=1.24,<2.0",
+]
 
 [build-system]
 requires = ["setuptools>=61.0"]

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,6 @@
 matplotlib
 pytest
 pandas
-numpy>=1.22             # for numpy typing stubs
 rouge-score>=0.1.2      # 日本語Rouge-L用
 fugashi>=1.3            # MeCab wrapper
 ipadic>=1.0             # MeCab dictionary
@@ -13,6 +12,7 @@ bert-score
 mypy
 types-PyYAML          # for mypy stub of PyYAML
 # ---------------- core ML / NLP 依存 ----------------
+numpy==1.26.*
 torch>=2.4
 sentencepiece>=0.1.99
 sentence-transformers>=2.6


### PR DESCRIPTION
## Summary
- add `numpy` as a runtime dependency
- declare runtime deps in `pyproject.toml`
- make collector workflow install requirements with cache

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6878ccd70f308330b342540f9557fe2c