### PR TITLE
Add build artifacts to CI

### DIFF
--- a/.github/actions/setup-deps/action.yml
+++ b/.github/actions/setup-deps/action.yml
@@ -20,3 +20,7 @@ runs:
     - name: Install project (dev)
       run: pip install -e .[dev]
       shell: bash
+
+    - name: Build package
+      run: python -m build --sdist --wheel
+      shell: bash

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -71,3 +71,10 @@ jobs:
       - name: Static type check (mypy)
         run: mypy .
       - run: pytest -q
+      - name: Upload build artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: package
+          path: |
+            dist/*.whl
+            dist/*.tar.gz

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,6 +32,7 @@ dev = [
   "openai>=1.14",
   "tenacity>=8.0",
   "build>=0.10",
+  "build",
 ]
 
 [build-system]


### PR DESCRIPTION
## Summary
- ensure `build` is available in dev extras
- run `python -m build --sdist --wheel` in setup action
- upload built artifacts from CI workflow

## Testing
- `pytest -q`
- `mypy .`

------
https://chatgpt.com/codex/tasks/task_e_687963cd232c8330ba10387a5b5e0fcb