### PR TITLE
Add docs and CLI for por_fire extraction

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,6 +111,8 @@ python examples/visualize_tensor.py --demo
 
 ## UGH3 Metrics 指標定義
 このライブラリで扱う UGH3 指標（内部ダイナミクス評価メトリクス）は以下の通りです。
+- `core.metrics` に `POR_FIRE_THRESHOLD = 0.82` を追加しました。
+- `scripts/extract_metrics.py` は新たに `por_fire` 列を出力します。
 
 ### 1. PoR（Point of Resonance）
 - **定義：** 照合強度のスコア。問いと応答の意味的整合性・圧力・時間的同期性を反映。

--- a/core/__init__.py
+++ b/core/__init__.py
@@ -5,6 +5,7 @@ from .grv_v4 import score as grv_v4, set_params as set_grv_params
 from .por_v4 import calc_por_v4 as por_score, set_params as set_por_params
 from .sci import sci, reset_state as reset_sci_state
 from .history import evaluate_record, GOOD, OKAY, BAD
+from .metrics import is_por_fire, POR_FIRE_THRESHOLD
 
 __all__ = [
     "deltae_score",
@@ -17,6 +18,8 @@ __all__ = [
     "GOOD",
     "OKAY",
     "BAD",
+    "is_por_fire",
+    "POR_FIRE_THRESHOLD",
     "set_deltae_params",
     "set_grv_params",
     "set_por_params",

--- a/core/metrics.py
+++ b/core/metrics.py
@@ -1,0 +1,13 @@
+"""Utility helpers for metric thresholds."""
+
+from __future__ import annotations
+
+POR_FIRE_THRESHOLD: float = 0.82
+"""Threshold at which PoR is considered fired."""
+
+
+def is_por_fire(score: float) -> bool:
+    """True if score >= POR_FIRE_THRESHOLD."""
+    return score >= POR_FIRE_THRESHOLD
+
+__all__ = ["POR_FIRE_THRESHOLD", "is_por_fire"]

--- a/docs/metrics.md
+++ b/docs/metrics.md
@@ -1,0 +1,7 @@
+# Metric Thresholds
+
+| Level | PoR Score Range | Description |
+|-------|-----------------|-------------|
+| Safe | < 0.60 | Normal conversation. |
+| Caution | >= 0.60 and < 0.82 | Elevated but below firing threshold. |
+| Fired | >= 0.82 | PoR event is fired. |

--- a/scripts/extract_metrics.py
+++ b/scripts/extract_metrics.py
@@ -1,0 +1,66 @@
+"""Add ``por_fire`` field to JSONL metrics files.
+
+Usage examples::
+
+    python extract_metrics.py --infile data.jsonl --outfile out.jsonl
+    python extract_metrics.py datasets/*.jsonl > merged.jsonl
+"""
+
+import argparse
+import json
+from pathlib import Path
+from typing import Any, Dict, Iterable
+import sys
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
+
+from core.metrics import is_por_fire
+
+
+def parse_args() -> argparse.Namespace:
+    p = argparse.ArgumentParser(description="Add por_fire flag to JSONL records")
+    p.add_argument("paths", nargs="*", type=Path, help="Input JSONL paths")
+    p.add_argument("--infile", type=Path)
+    p.add_argument("--outfile", type=Path)
+    return p.parse_args()
+
+
+def _process_stream(fh_in: Iterable[str], fh_out) -> None:
+    for line in fh_in:
+        line = line.strip()
+        if not line:
+            continue
+        j: Dict[str, Any] = json.loads(line)
+        if "por" in j:
+            por_val = j.get("por")
+            if por_val is None or (
+                isinstance(por_val, str) and por_val.strip() == ""
+            ):
+                j["por_fire"] = False
+            else:
+                try:
+                    j["por_fire"] = is_por_fire(float(por_val))
+                except (TypeError, ValueError):
+                    j["por_fire"] = False
+        json.dump(j, fh_out, ensure_ascii=False)
+        fh_out.write("\n")
+
+
+def main() -> None:
+    args = parse_args()
+    if args.infile:
+        out_fh = args.outfile.open("w", encoding="utf-8") if args.outfile else sys.stdout
+        with args.infile.open("r", encoding="utf-8") as fh_in:
+            _process_stream(fh_in, out_fh)
+        if out_fh is not sys.stdout:
+            out_fh.close()
+    else:
+        if not args.paths:
+            raise SystemExit("no input files provided")
+        for path in args.paths:
+            with path.open("r", encoding="utf-8") as fh_in:
+                _process_stream(fh_in, sys.stdout)
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/fixtures/sample.jsonl
+++ b/tests/fixtures/sample.jsonl
@@ -1,0 +1,2 @@
+{"text": "hello", "por": "0.81"}
+{"text": "world", "por": "0.83"}

--- a/tests/test_por_fire.py
+++ b/tests/test_por_fire.py
@@ -1,0 +1,15 @@
+import pytest
+
+from core.metrics import POR_FIRE_THRESHOLD, is_por_fire
+
+
+@pytest.mark.parametrize(
+    "score,expected",
+    [
+        (0.81, False),
+        (POR_FIRE_THRESHOLD, True),
+        (0.95, True),
+    ],
+)
+def test_is_por_fire(score: float, expected: bool) -> None:
+    assert is_por_fire(score) is expected


### PR DESCRIPTION
## Summary
- document POR_FIRE_THRESHOLD and `por_fire` output
- add metrics threshold table in docs
- extend `extract_metrics.py` CLI with streaming mode
- include sample fixture for manual runs

## Testing
- `pytest -q`
- `python scripts/extract_metrics.py tests/fixtures/sample.jsonl > /dev/null`

------
https://chatgpt.com/codex/tasks/task_e_687a32b28fdc8330b3a03ce9a55c3aba