### PR TITLE
Fix CLI test variable names

### DIFF
--- a/.ruff.toml
+++ b/.ruff.toml
@@ -1,5 +1,6 @@
 target-version = "py39"
 line-length = 120
+extend-exclude = ["examples/*.ipynb"]
 
 [lint]
 select = ["F", "E"]

--- a/tests/test_extract_metrics_cli.py
+++ b/tests/test_extract_metrics_cli.py
@@ -13,7 +13,11 @@ def test_cli_smoke() -> None:
         text=True,
         check=True,
     )
-    outs = [json.loads(l) for l in proc.stdout.strip().splitlines()]
-    fired = {rec["por_fire"] for rec in outs}
+    outs = []
+    for line in proc.stdout.strip().splitlines():
+        record = json.loads(line)
+        outs.append(record)
+
+    fired = {record["por_fire"] for record in outs}
     assert fired == {False, True}
 


### PR DESCRIPTION
## Summary
- expand variable names in tests to avoid E741
- skip Ruff linting on `.ipynb` examples

## Testing
- `ruff check --ignore F401 .`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'numpy')*

------
https://chatgpt.com/codex/tasks/task_e_68802b6fbe188330ac7d049ae962d526