### PR TITLE
Add delta-e internal metric and inference CLI

### DIFF
--- a/core/metrics.py
+++ b/core/metrics.py
@@ -1,6 +1,10 @@
-"""Utility helpers for metric thresholds."""
+"""Utility helpers for metric thresholds and simple metrics."""
 
 from __future__ import annotations
+
+import numpy as np
+from numpy.typing import NDArray
+from sklearn.metrics.pairwise import cosine_similarity
 
 POR_FIRE_THRESHOLD: float = 0.82
 """Threshold at which PoR is considered fired."""
@@ -10,4 +14,12 @@ def is_por_fire(score: float) -> bool:
     """True if score >= POR_FIRE_THRESHOLD."""
     return score >= POR_FIRE_THRESHOLD
 
-__all__ = ["POR_FIRE_THRESHOLD", "is_por_fire"]
+
+def calc_delta_e_internal(prev_vec: NDArray[np.float64], new_vec: NDArray[np.float64]) -> float:
+    """ΔE (internal) = 1 - cosine_similarity(prev_vec, new_vec), clipped to [0,1]."""
+    sim = float(cosine_similarity(prev_vec.reshape(1, -1), new_vec.reshape(1, -1)))
+    delta = 1.0 - sim
+    return max(0.0, min(1.0, delta))
+
+
+__all__ = ["POR_FIRE_THRESHOLD", "is_por_fire", "calc_delta_e_internal"]

--- a/models/run_inference.py
+++ b/models/run_inference.py
@@ -1,0 +1,77 @@
+#!/usr/bin/env python3
+"""Run text inference and compute ΔE internal metrics."""
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+from pathlib import Path
+from typing import Callable, List
+import sys
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
+
+import numpy as np
+
+from core.metrics import calc_delta_e_internal
+
+
+def _build_encoder(model_name: str) -> Callable[[str], np.ndarray]:
+    """Return a text encoder. Uses transformers if available."""
+    try:
+        from transformers import AutoModel, AutoTokenizer
+        import torch
+
+        tok = AutoTokenizer.from_pretrained(model_name)
+        mdl = AutoModel.from_pretrained(model_name)
+
+        def encode(text: str) -> np.ndarray:
+            tokens = tok(text, return_tensors="pt")
+            with torch.no_grad():
+                out = mdl(**tokens).last_hidden_state.mean(dim=1)
+            return out.squeeze().numpy()
+
+        return encode
+    except Exception:
+        def encode(text: str) -> np.ndarray:
+            h = int.from_bytes(hashlib.md5(text.encode()).digest()[:4], "big")
+            return np.asarray([len(text), h], dtype=float)
+
+        return encode
+
+
+def parse_args() -> argparse.Namespace:
+    p = argparse.ArgumentParser(description="Run inference on text input")
+    p.add_argument("--model", default="sentence-transformers/all-MiniLM-L6-v2")
+    g = p.add_mutually_exclusive_group(required=True)
+    g.add_argument("--prompt", type=str, help="prompt string")
+    g.add_argument("--infile", type=Path, help="path to input text file")
+    p.add_argument("--dump-hidden", type=Path, help="write hidden vectors to JSONL")
+    return p.parse_args()
+
+
+def main() -> None:
+    args = parse_args()
+    encode = _build_encoder(args.model)
+
+    if args.prompt is not None:
+        lines = [args.prompt]
+    else:
+        content = args.infile.read_text(encoding="utf-8")
+        lines = [ln.strip() for ln in content.splitlines() if ln.strip()]
+
+    vecs: List[np.ndarray] = [encode(line) for line in lines]
+
+    for i in range(1, len(vecs)):
+        de = calc_delta_e_internal(vecs[i-1], vecs[i])
+        print(f"{de:.3f}")
+
+    if args.dump_hidden:
+        with open(args.dump_hidden, "w", encoding="utf-8") as fh:
+            for i, v in enumerate(vecs):
+                json.dump({"turn": i, "hidden_state": v.tolist()}, fh)
+                fh.write("\n")
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/test_delta_e_internal.py
+++ b/tests/test_delta_e_internal.py
@@ -1,0 +1,31 @@
+import numpy as np
+import pytest
+
+from core.metrics import calc_delta_e_internal
+
+
+def test_delta_e_internal_identical() -> None:
+    v1 = np.array([1.0, 0.0])
+    assert calc_delta_e_internal(v1, v1) == 0.0
+
+
+def test_delta_e_internal_orthogonal() -> None:
+    v1 = np.array([1.0, 0.0])
+    v2 = np.array([0.0, 1.0])
+    assert pytest.approx(calc_delta_e_internal(v1, v2), abs=0.05) == 1.0
+
+
+def test_delta_e_internal_clip() -> None:
+    v1 = np.array([1.0, 0.0])
+    v2 = np.array([-1.0, 0.0])
+    assert calc_delta_e_internal(v1, v2) == 1.0
+
+
+def test_delta_e_internal_random_unit_vectors() -> None:
+    rng = np.random.default_rng(42)
+    v1 = rng.normal(size=768)
+    v1 /= np.linalg.norm(v1)
+    v2 = rng.normal(size=768)
+    v2 /= np.linalg.norm(v2)
+    de = calc_delta_e_internal(v1, v2)
+    assert 0.0 <= de <= 1.0

--- a/tests/test_inference_cli.py
+++ b/tests/test_inference_cli.py
@@ -1,0 +1,36 @@
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+pytest.importorskip("transformers", reason="HF not installed")
+
+
+def test_run_inference_cli(tmp_path: Path) -> None:
+    txt_path = tmp_path / "input.txt"
+    txt_path.write_text("hello\nworld\n", encoding="utf-8")
+    jsonl_path = tmp_path / "out.jsonl"
+    subprocess.run(
+        [
+            sys.executable,
+            "models/run_inference.py",
+            "--model",
+            "sentence-transformers/all-MiniLM-L6-v2",
+            "--infile",
+            str(txt_path),
+            "--dump-hidden",
+            str(jsonl_path),
+        ],
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+    assert jsonl_path.exists()
+    lines = jsonl_path.read_text(encoding="utf-8").splitlines()
+    assert len(lines) == 2
+    for i, line in enumerate(lines):
+        record = json.loads(line)
+        assert record["turn"] == i
+        assert isinstance(record["hidden_state"], list)


### PR DESCRIPTION
## Summary
- implement `calc_delta_e_internal` using sklearn cosine similarity
- add `models/run_inference.py` CLI with optional HF model encoding and JSONL dumping
- extend ΔE internal tests and add CLI test

## Testing
- `python -m ruff check --ignore F401 .`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688081e89fd48330a263f96e569bfb9f