### PR TITLE
Externalize GRV weights

### DIFF
--- a/config/grv.yaml
+++ b/config/grv.yaml
@@ -1,0 +1,3 @@
+tfidf: 0.50
+entropy: 0.30
+cooccurrence: 0.20

--- a/core/grv.py
+++ b/core/grv.py
@@ -9,7 +9,27 @@ capped at ``1.0``.
 from __future__ import annotations
 
 from typing import Iterable
+from pathlib import Path
+import yaml
 from math import log2
+
+
+def load_grv_weights() -> tuple[float, float, float]:
+    """Return GRV component weights from YAML, fallback to defaults."""
+    path = Path(__file__).resolve().parents[1] / "config" / "grv.yaml"
+    try:
+        with open(path, "r", encoding="utf-8") as fh:
+            data = yaml.safe_load(fh) or {}
+    except Exception:
+        data = {}
+    return (
+        float(data.get("tfidf", 0.42)),
+        float(data.get("entropy", 0.31)),
+        float(data.get("cooccurrence", 0.27)),
+    )
+
+
+DEFAULT_WEIGHTS: tuple[float, float, float] = load_grv_weights()
 
 
 def _collect_vocab(texts: Iterable[str]) -> set[str]:
@@ -58,4 +78,4 @@ def grv_score(text: str | list[str], *, vocab_limit: int = 30, mode: str = "simp
     raise ValueError("invalid mode")
 
 
-__all__ = ["grv_score"]
+__all__ = ["grv_score", "load_grv_weights"]

--- a/tests/test_grv_yaml.py
+++ b/tests/test_grv_yaml.py
@@ -1,0 +1,11 @@
+import importlib
+
+from ugh3_metrics.metrics.grv_v4 import GrvV4
+
+
+def test_yaml_weights_loaded() -> None:
+    # reload module to ensure YAML is read
+    mod = importlib.reload(importlib.import_module('ugh3_metrics.metrics.grv_v4'))
+    weights = mod.GrvV4.DEFAULT_WEIGHTS
+    assert weights == (0.5, 0.3, 0.2)
+

--- a/ugh3_metrics/metrics/grv_v4.py
+++ b/ugh3_metrics/metrics/grv_v4.py
@@ -1,6 +1,8 @@
 from __future__ import annotations
 
 from typing import Iterable, List, Any
+from pathlib import Path
+import yaml
 
 import numpy as np
 
@@ -9,10 +11,25 @@ from ..models.embedder import EmbedderProtocol
 from ..utils import tokenize, tfidf_topk, entropy, pmi
 
 
+def load_grv_weights() -> tuple[float, float, float]:
+    """Load default weights from YAML if available."""
+    path = Path(__file__).resolve().parents[2] / "config" / "grv.yaml"
+    try:
+        with open(path, "r", encoding="utf-8") as fh:
+            data = yaml.safe_load(fh) or {}
+    except Exception:
+        data = {}
+    return (
+        float(data.get("tfidf", 0.42)),
+        float(data.get("entropy", 0.31)),
+        float(data.get("cooccurrence", 0.27)),
+    )
+
+
 class GrvV4(BaseMetric):
     """Lexical gravity v4 metric (TF-IDF + PMI + Entropy)."""
 
-    DEFAULT_WEIGHTS: tuple[float, float, float] = (0.42, 0.31, 0.27)
+    DEFAULT_WEIGHTS: tuple[float, float, float] = load_grv_weights()
     DEFAULT_WINDOW: int = 50
 
     def __init__(self, *, embedder: EmbedderProtocol | None = None) -> None:


### PR DESCRIPTION
## Summary
- externalise GrvV4 default weights into YAML
- expose loader via `load_grv_weights`
- align `core.grv` exports with `grv_v4`

## Testing
- `python -m ruff check --ignore F401 .`
- `python -m mypy --strict --disable-error-code import-not-found .`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6884ebb43c8883308f355abab7c38e55