### PR TITLE
Update CI for Python 3.9 and 3.12

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,6 +14,9 @@ permissions:
 jobs:
   test:
     runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        python-version: ["3.9", "3.12"]
     env:
       PYTHONPATH: ${{ github.workspace }}
       ST_CACHE: ${{ github.workspace }}/.cache/st
@@ -21,7 +24,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: ./.github/actions/setup-deps
         with:
-          python-version: "3.12"
+          python-version: "${{ matrix.python-version }}"
       - name: Clear all caches
         run: |
           find . -name "*.pyc" -delete


### PR DESCRIPTION
## Summary
- run workflow tests on Python 3.9 and 3.12

## Testing
- `python -m ruff check --ignore F401 .`
- `mypy --strict --disable-error-code import-not-found .`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6885789eb6148330bf5ef64b2f4d0e63