### PR TITLE
Fix artifact name for matrix CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -76,7 +76,7 @@ jobs:
       - name: Upload build artifacts
         uses: actions/upload-artifact@v4
         with:
-          name: package
+          name: package-${{ matrix.python-version }}
           path: |
             dist/*.whl
             dist/*.tar.gz


### PR DESCRIPTION
## Summary
- avoid 409 Conflict when parallel CI jobs upload artifacts by including the Python version in the artifact name

## Testing
- `python -m ruff check --ignore F401 .`

------
https://chatgpt.com/codex/tasks/task_e_688615d411c08330aa9f912e6c904acf