### PR TITLE
Add dataset analysis utility

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -73,3 +73,4 @@ Thumbs.db
 backups/
 runs/
 temp_comet/
+/analysis_output/

--- a/README.md
+++ b/README.md
@@ -111,6 +111,13 @@ python examples/visualize_tensor.py --demo
 ![Phase Map](images/phase_map.png)
 ![Tensor](images/tensor.png)
 
+### Dataset Analysis
+
+```bash
+python scripts/analyze_dataset.py --infile datasets/current_recalc.parquet
+open analysis_output/report.md
+```
+
 ## UGH3 Metrics 指標定義
 このライブラリで扱う UGH3 指標（内部ダイナミクス評価メトリクス）は以下の通りです。
 - `core.metrics` に `POR_FIRE_THRESHOLD = 0.82` を追加しました。

--- a/scripts/analyze_dataset.py
+++ b/scripts/analyze_dataset.py
@@ -1,0 +1,86 @@
+from __future__ import annotations
+
+import argparse
+from pathlib import Path
+
+import pandas as pd
+import matplotlib
+
+matplotlib.use("Agg")  # for CI/non-GUI environments
+import matplotlib.pyplot as plt
+
+
+def parse_args() -> argparse.Namespace:
+    p = argparse.ArgumentParser(description="Analyze dataset and generate report")
+    p.add_argument(
+        "--infile",
+        type=Path,
+        default=Path("datasets/current_recalc.parquet"),
+        help="input Parquet file",
+    )
+    p.add_argument(
+        "--outdir",
+        type=Path,
+        default=Path("analysis_output"),
+        help="output directory",
+    )
+    return p.parse_args()
+
+
+def main() -> None:
+    args = parse_args()
+    outdir = args.outdir
+    outdir.mkdir(parents=True, exist_ok=True)
+
+    df = pd.read_parquet(args.infile)
+    columns = [
+        "delta_e_internal",
+        "por_fire",
+        "tfidf",
+        "entropy",
+        "cooccurrence",
+        "grv_score",
+    ]
+    present = [c for c in columns if c in df.columns]
+    if not present:
+        raise SystemExit("no required columns found")
+
+    summary_df = df[present].describe()
+
+    if "delta_e_internal" in df.columns:
+        plt.figure()
+        df["delta_e_internal"].dropna().hist(bins=30)
+        plt.title("delta_e_internal distribution")
+        plt.savefig(outdir / "hist_delta_e.png")
+        plt.close()
+
+    if "por_fire" in df.columns:
+        plt.figure()
+        df["por_fire"].value_counts().sort_index().plot.bar()
+        plt.title("por_fire rate")
+        plt.savefig(outdir / "bar_por_fire.png")
+        plt.close()
+
+    if "delta_e_internal" in df.columns and "grv_score" in df.columns:
+        plt.figure()
+        plt.scatter(df["delta_e_internal"], df["grv_score"])
+        plt.title("delta_e_internal vs grv_score")
+        plt.xlabel("delta_e_internal")
+        plt.ylabel("grv_score")
+        plt.savefig(outdir / "scatter_delta_vs_grv.png")
+        plt.close()
+
+    report_path = outdir / "report.md"
+    with report_path.open("w", encoding="utf-8") as fh:
+        fh.write("# Dataset Analysis\n\n")
+        fh.write(f"Dataset size: {len(df)}\n\n")
+        fh.write(summary_df.to_markdown())
+        fh.write("\n\n")
+        fh.write("![](hist_delta_e.png)\n")
+        fh.write("![](bar_por_fire.png)\n")
+        if (outdir / "scatter_delta_vs_grv.png").exists():
+            fh.write("![](scatter_delta_vs_grv.png)\n")
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/test_analyze_dataset_smoke.py
+++ b/tests/test_analyze_dataset_smoke.py
@@ -1,0 +1,38 @@
+from __future__ import annotations
+
+import subprocess
+import sys
+from pathlib import Path
+
+import numpy as np
+import pandas as pd
+
+
+def test_analyze_dataset_smoke(tmp_path: Path) -> None:
+    df = pd.DataFrame(
+        {
+            "delta_e_internal": np.random.rand(100),
+            "por_fire": np.random.choice([True, False], size=100),
+            "tfidf": np.random.rand(100),
+            "entropy": np.random.rand(100),
+            "cooccurrence": np.random.rand(100),
+            "grv_score": np.random.rand(100),
+        }
+    )
+    infile = tmp_path / "sample.parquet"
+    df.to_parquet(infile)
+
+    outdir = tmp_path / "analysis_output"
+    subprocess.run(
+        [sys.executable, "scripts/analyze_dataset.py", "--infile", str(infile), "--outdir", str(outdir)],
+        check=True,
+    )
+
+    assert (outdir / "report.md").exists()
+    assert (outdir / "hist_delta_e.png").exists()
+    assert (outdir / "bar_por_fire.png").exists()
+    assert (outdir / "scatter_delta_vs_grv.png").exists()
+
+    report_text = (outdir / "report.md").read_text(encoding="utf-8")
+    assert "count" in report_text
+    assert str(len(df)) in report_text


### PR DESCRIPTION
## Summary
- add `analyze_dataset.py` to generate Markdown summary and plots
- append `analysis_output/` to `.gitignore`
- show how to run dataset analysis in README
- test dataset analysis script

## Testing
- `python -m ruff check --ignore F401 .`
- `mypy --strict --disable-error-code import-not-found .` *(fails: Error importing plugin "pydantic.mypy")*
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'numpy')*

------
https://chatgpt.com/codex/tasks/task_e_688621b2ee1c8330965765977b0b1406