### PR TITLE
Implement dataset evaluation CLI

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,6 +117,11 @@ python examples/visualize_tensor.py --demo
 python scripts/analyze_dataset.py --infile datasets/current_recalc.parquet
 open analysis_output/report.md
 ```
+```bash
+python scripts/evaluate_dataset.py \
+    --infile datasets/current_recalc.parquet \
+    --outdir evaluation_output
+```
 
 ## UGH3 Metrics 指標定義
 このライブラリで扱う UGH3 指標（内部ダイナミクス評価メトリクス）は以下の通りです。

--- a/scripts/evaluate_dataset.py
+++ b/scripts/evaluate_dataset.py
@@ -1,0 +1,78 @@
+from __future__ import annotations
+
+import argparse
+import sys
+from pathlib import Path
+
+import pandas as pd
+
+
+def parse_args() -> argparse.Namespace:
+    p = argparse.ArgumentParser(description="Evaluate dataset for public release")
+    p.add_argument(
+        "--infile",
+        type=Path,
+        default=Path("datasets/current_recalc.parquet"),
+        help="input dataset file (Parquet/CSV/JSONL)",
+    )
+    p.add_argument(
+        "--outdir",
+        type=Path,
+        default=Path("evaluation_output"),
+        help="output directory",
+    )
+    return p.parse_args()
+
+
+def load_table(path: Path) -> pd.DataFrame:
+    ext = path.suffix.lower()
+    if ext in {".parquet", ".pq", ".parq"}:
+        return pd.read_parquet(path)
+    if ext == ".jsonl":
+        return pd.read_json(path, lines=True)
+    return pd.read_csv(path)
+
+
+def main() -> int:
+    args = parse_args()
+    infile = args.infile
+    if not infile.exists():
+        print(f"WARNING: {infile} not found", file=sys.stderr)
+        return 3
+
+    outdir = args.outdir
+    outdir.mkdir(parents=True, exist_ok=True)
+
+    df = load_table(infile)
+
+    count_ok = len(df) >= 1000
+
+    if "delta_e_internal" in df.columns:
+        frac_valid = (
+            df["delta_e_internal"].dropna().between(0, 1, inclusive="both").mean()
+        )
+    else:
+        frac_valid = 0.0
+    delta_ok = frac_valid >= 0.99
+
+    if "por_fire" in df.columns:
+        rate = float(df["por_fire"].mean())
+    else:
+        rate = 0.0
+    por_ok = 0.1 <= rate <= 0.4
+
+    all_ok = count_ok and delta_ok and por_ok
+
+    report = outdir / "report.md"
+    with report.open("w", encoding="utf-8") as fh:
+        fh.write("# Dataset Evaluation\n\n")
+        fh.write(f"Total records: {len(df)}\n\n")
+        fh.write(f"Valid delta_e_internal: {frac_valid*100:.2f}%\n\n")
+        fh.write(f"por_fire rate: {rate:.3f}\n\n")
+        fh.write("Status: **PASS**\n" if all_ok else "Status: **FAIL**\n")
+
+    return 0 if all_ok else 2
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_evaluate_dataset_smoke.py
+++ b/tests/test_evaluate_dataset_smoke.py
@@ -1,0 +1,34 @@
+from __future__ import annotations
+
+import subprocess
+import sys
+from pathlib import Path
+
+import numpy as np
+import pandas as pd
+import pytest
+
+
+def make_df(kind: str, rows: int) -> pd.DataFrame:
+    if kind == "good":
+        return pd.DataFrame({
+            "delta_e_internal": np.clip(np.random.rand(rows), 0, 1),
+            "por_fire": np.random.choice([True, False], size=rows, p=[0.25, 0.75]),
+        })
+    return pd.DataFrame({
+        "delta_e_internal": np.concatenate([np.ones(rows - 1), np.array([1.5])]),
+        "por_fire": np.random.choice([True, False], size=rows),
+    })
+
+
+@pytest.mark.parametrize("kind,rows,expected", [("good", 1200, 0), ("bad", 50, 2)])  # type: ignore[misc]
+def test_evaluate_dataset_smoke(tmp_path: Path, kind: str, rows: int, expected: int) -> None:
+    df = make_df(kind, rows)
+    infile = tmp_path / "in.parquet"
+    df.to_parquet(infile)
+    outdir = tmp_path / "out"
+    result = subprocess.run(
+        [sys.executable, "scripts/evaluate_dataset.py", "--infile", str(infile), "--outdir", str(outdir)]
+    )
+    assert result.returncode == expected
+    assert (outdir / "report.md").exists()


### PR DESCRIPTION
## Summary
- add `evaluate_dataset.py` CLI for validating dataset quality
- test evaluation CLI with good/bad datasets
- document dataset evaluation in README

## Testing
- `python -m ruff check --ignore F401 .`
- `mypy --strict .`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688735b4e6748330ae85b18eeeabb29c