### PR TITLE
Add effect size evaluation in dataset script

### DIFF
--- a/tests/test_evaluate_dataset_smoke.py
+++ b/tests/test_evaluate_dataset_smoke.py
@@ -10,25 +10,36 @@ import pytest
 
 
 def make_df(kind: str, rows: int) -> pd.DataFrame:
+    groups = np.random.choice([True, False], size=rows, p=[0.25, 0.75])
     if kind == "good":
-        return pd.DataFrame({
-            "delta_e_internal": np.clip(np.random.rand(rows), 0, 1),
-            "por_fire": np.random.choice([True, False], size=rows, p=[0.25, 0.75]),
-        })
+        delta = np.where(groups, np.random.normal(0.2, 0.05, size=rows), np.random.normal(0.8, 0.05, size=rows))
+    else:
+        delta = np.where(groups, np.random.normal(0.5, 0.05, size=rows), np.random.normal(0.51, 0.05, size=rows))
     return pd.DataFrame({
-        "delta_e_internal": np.concatenate([np.ones(rows - 1), np.array([1.5])]),
-        "por_fire": np.random.choice([True, False], size=rows),
+        "delta_e_internal": np.clip(delta, 0, 1),
+        "por_fire": groups,
     })
 
 
-@pytest.mark.parametrize("kind,rows,expected", [("good", 1200, 0), ("bad", 50, 2)])  # type: ignore[misc]
+@pytest.mark.parametrize("kind,rows,expected", [("good", 1200, 0), ("bad", 1200, 2)])  # type: ignore[misc]
 def test_evaluate_dataset_smoke(tmp_path: Path, kind: str, rows: int, expected: int) -> None:
     df = make_df(kind, rows)
     infile = tmp_path / "in.parquet"
     df.to_parquet(infile)
     outdir = tmp_path / "out"
     result = subprocess.run(
-        [sys.executable, "scripts/evaluate_dataset.py", "--infile", str(infile), "--outdir", str(outdir)]
+        [
+            sys.executable,
+            "scripts/evaluate_dataset.py",
+            "--infile",
+            str(infile),
+            "--outdir",
+            str(outdir),
+            "--group-col",
+            "por_fire",
+            "--metric-cols",
+            "delta_e_internal",
+        ]
     )
     assert result.returncode == expected
     assert (outdir / "report.md").exists()


### PR DESCRIPTION
## Summary
- evaluate dataset via effect size and Welch t-test
- expose `--group-col` and `--metric-cols` CLI arguments
- fail when effect size too small
- test good/bad cases for dataset evaluation

## Testing
- `pytest tests/test_evaluate_dataset_smoke.py::test_evaluate_dataset_smoke -q`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68878c6aea4483308829495e33a3cae9