### PR TITLE
Add build_dataset automation

### DIFF
--- a/.github/workflows/build_dataset.yml
+++ b/.github/workflows/build_dataset.yml
@@ -1,0 +1,27 @@
+name: Build Dataset Nightly
+
+on:
+  workflow_dispatch:
+  schedule:
+    - cron: "0 0 * * *"
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: ./.github/actions/setup-deps
+      - name: Build dataset
+        run: python scripts/build_dataset.py
+      - name: Upload artefact
+        uses: actions/upload-artifact@v4
+        with:
+          name: nightly-dataset
+          path: datasets/current_recalc.parquet
+      - name: Create PR if changed
+        uses: peter-evans/create-pull-request@v6
+        with:
+          commit-message: "Nightly dataset update"
+          title: "Automated dataset update"
+          branch: "dataset/nightly"
+          delete-branch: true

--- a/README.md
+++ b/README.md
@@ -111,6 +111,16 @@ python examples/visualize_tensor.py --demo
 ![Phase Map](images/phase_map.png)
 ![Tensor](images/tensor.png)
 
+### Dataset Build
+The `build_dataset.py` script bundles CSV files under `raw/` and
+recalculates metrics into a Parquet dataset.
+
+```bash
+python scripts/build_dataset.py \
+  --raw-dir raw/ \
+  --out-parquet datasets/current_recalc.parquet
+```
+
 ### Dataset Analysis
 
 ```bash

--- a/scripts/build_dataset.py
+++ b/scripts/build_dataset.py
@@ -1,0 +1,80 @@
+#!/usr/bin/env python3
+"""Build dataset from raw CSV files into a single Parquet table."""
+from __future__ import annotations
+
+import argparse
+import subprocess
+import sys
+from pathlib import Path
+import tempfile
+
+import pandas as pd
+
+
+
+def parse_args() -> argparse.Namespace:
+    p = argparse.ArgumentParser(description="Combine raw CSVs and recalc metrics")
+    p.add_argument("--raw-dir", type=Path, default=Path("raw"), help="directory of raw CSV files")
+    p.add_argument(
+        "--out-parquet",
+        type=Path,
+        default=Path("datasets/current_recalc.parquet"),
+        help="output Parquet file",
+    )
+    return p.parse_args()
+
+
+def load_raw_csvs(raw_dir: Path) -> pd.DataFrame:
+    files = sorted(raw_dir.glob("*.csv"))
+    if not files:
+        raise FileNotFoundError("no CSV files found")
+    frames = [pd.read_csv(f) for f in files]
+    df = pd.concat(frames, ignore_index=True)
+
+    rename_map = {"Q": "question", "A1": "answer_a", "A2": "answer_b"}
+    df = df.rename(columns={k: v for k, v in rename_map.items() if k in df.columns})
+    for col in ["question", "answer_a", "answer_b"]:
+        if col in df.columns:
+            df[col] = df[col].astype(str)
+
+    if "por_fire" not in df.columns:
+        if "por" in df.columns:
+            por_val = pd.to_numeric(df["por"], errors="coerce").fillna(0.0)
+            df["por_fire"] = por_val >= 0.1
+        else:
+            df["por_fire"] = False
+    return df
+
+
+def main() -> int:
+    args = parse_args()
+    try:
+        df = load_raw_csvs(args.raw_dir)
+    except FileNotFoundError:
+        return 3
+    except Exception as e:  # pragma: no cover - defensive
+        print(f"[ERROR] {e}", file=sys.stderr)
+        return 1
+
+    args.out_parquet.parent.mkdir(parents=True, exist_ok=True)
+
+    with tempfile.NamedTemporaryFile(suffix=".csv", delete=False) as tmp:
+        temp_path = Path(tmp.name)
+        df.to_csv(temp_path, index=False)
+
+    recalc = Path(__file__).resolve().parent / "recalc_scores_v4.py"
+    try:
+        subprocess.run(
+            [sys.executable, str(recalc), "--infile", str(temp_path), "--outfile", str(args.out_parquet)],
+            check=True,
+        )
+    except subprocess.CalledProcessError:
+        return 1
+    finally:
+        temp_path.unlink(missing_ok=True)
+
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_build_dataset_smoke.py
+++ b/tests/test_build_dataset_smoke.py
@@ -1,0 +1,26 @@
+from __future__ import annotations
+
+import subprocess
+import sys
+from pathlib import Path
+
+import pandas as pd
+
+
+def test_build_dataset_smoke(tmp_path: Path) -> None:
+    raw = tmp_path / "raw"
+    raw.mkdir()
+    df1 = pd.DataFrame({"question": ["q1"], "answer_a": ["a1"], "answer_b": ["b1"], "por": [0.2]})
+    df2 = pd.DataFrame({"question": ["q2"], "answer_a": ["a2"], "answer_b": ["b2"], "por": [0.3]})
+    df1.to_csv(raw / "a.csv", index=False)
+    df2.to_csv(raw / "b.csv", index=False)
+
+    out = tmp_path / "out.parquet"
+    proc = subprocess.run(
+        [sys.executable, "scripts/build_dataset.py", "--raw-dir", str(raw), "--out-parquet", str(out)],
+        check=False,
+    )
+    assert proc.returncode == 0
+    assert out.exists()
+    df = pd.read_parquet(out)
+    assert len(df) == len(df1) + len(df2)


### PR DESCRIPTION
## Summary
- implement `build_dataset.py` to combine raw CSV files and recalc metrics
- add smoke test for the build script
- document the build step in README
- nightly workflow to run dataset build automatically

## Testing
- `python -m ruff check --ignore F401 .`
- `python -m mypy --strict .`
- `python -m pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6888099029ec83309badd3033b3377f5