### PR TITLE
Add workflow audit utility

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,6 +58,12 @@ python scripts/detect_duplicates.py --outdir dup_report
 open dup_report/report_dup.md
 ```
 
+### Workflow audit
+```bash
+python scripts/audit_workflows.py --out report/workflow_audit.md
+open report/workflow_audit.md
+```
+
 ## Quick Start / クイックスタート
 ```python
 from facade.trigger import por_trigger

--- a/scripts/audit_workflows.py
+++ b/scripts/audit_workflows.py
@@ -1,0 +1,110 @@
+#!/usr/bin/env python3
+"""Audit GitHub workflow files and detect duplicates."""
+from __future__ import annotations
+
+import argparse
+import difflib
+import sys
+from pathlib import Path
+from typing import Dict, List
+
+import yaml
+
+
+def load_workflow(path: Path) -> Dict[str, object]:
+    data = yaml.safe_load(path.read_text()) or {}
+    name = data.get("name", path.stem)
+    on = data.get("on", {})
+    if isinstance(on, dict):
+        triggers = list(on.keys())
+    elif isinstance(on, list):
+        triggers = [str(t) for t in on]
+    else:
+        triggers = [str(on)]
+    jobs = data.get("jobs", {}) or {}
+    job_names = list(jobs.keys())
+    steps: List[str] = []
+    for job in jobs.values():
+        for step in job.get("steps", [])[:2]:
+            if isinstance(step, dict):
+                name = step.get("name")
+                if name:
+                    steps.append(str(name))
+    tokens = job_names + steps
+    return {
+        "path": path,
+        "name": name,
+        "triggers": triggers,
+        "jobs": jobs,
+        "job_names": job_names,
+        "tokens": tokens,
+    }
+
+
+def diff_lines(a: Path, b: Path) -> str:
+    a_lines = a.read_text().splitlines()
+    b_lines = b.read_text().splitlines()
+    diff = difflib.unified_diff(a_lines, b_lines, fromfile=a.name, tofile=b.name, lineterm="")
+    lines = [d for d in diff if d.startswith(('+', '-')) and not d.startswith(('+++', '---'))]
+    return "\n".join(lines)
+
+
+def group_similar(wfs: List[Dict[str, object]]) -> List[List[Dict[str, object]]]:
+    groups: List[List[Dict[str, object]]] = []
+    used: set[Path] = set()
+    for i, w1 in enumerate(wfs):
+        if w1["path"] in used:
+            continue
+        group = [w1]
+        t1 = " ".join(sorted(w1["tokens"]))
+        for w2 in wfs[i + 1 :]:
+            t2 = " ".join(sorted(w2["tokens"]))
+            ratio = difflib.SequenceMatcher(None, t1, t2).ratio()
+            if ratio >= 0.8:
+                group.append(w2)
+                used.add(w2["path"])
+        if len(group) > 1:
+            for g in group:
+                used.add(g["path"])
+            groups.append(group)
+    return groups
+
+
+def generate_report(wfs: List[Dict[str, object]], groups: List[List[Dict[str, object]]]) -> str:
+    lines = ["# Workflow Audit", "", "## Summary", "| File | Workflow | Triggers | Jobs |", "| --- | --- | --- | --- |"]
+    for wf in wfs:
+        triggers = ", ".join(wf["triggers"])
+        lines.append(f"| {Path(wf['path']).name} | {wf['name']} | {triggers} | {len(wf['job_names'])} |")
+    for idx, group in enumerate(groups, 1):
+        lines.extend(["", f"## Duplicate group {idx}", "| File | Workflow | Jobs |", "| --- | --- | --- |"])
+        for wf in group:
+            lines.append(f"| {Path(wf['path']).name} | {wf['name']} | {', '.join(wf['job_names'])} |")
+        base = group[0]
+        for other in group[1:]:
+            diff = diff_lines(base["path"], other["path"])
+            lines.extend([
+                "",
+                f"### Diff with {Path(other['path']).name}",
+                "```diff",
+                diff,
+                "```",
+            ])
+    return "\n".join(lines) + "\n"
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--out", type=Path, default=Path("report/workflow_audit.md"))
+    args = parser.parse_args()
+
+    wf_dir = Path(".github/workflows")
+    wfs = [load_workflow(p) for p in wf_dir.glob("*.yml")]
+    groups = group_similar(wfs)
+    report = generate_report(wfs, groups)
+    args.out.parent.mkdir(parents=True, exist_ok=True)
+    args.out.write_text(report)
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/test_audit_workflows.py
+++ b/tests/test_audit_workflows.py
@@ -1,0 +1,45 @@
+from __future__ import annotations
+
+import subprocess
+import sys
+from pathlib import Path
+
+def test_audit_workflows(tmp_path: Path) -> None:
+    wf_dir = tmp_path / ".github" / "workflows"
+    wf_dir.mkdir(parents=True)
+    (wf_dir / "workflow1.yml").write_text(
+        """
+name: wf1
+on: [push]
+jobs:
+  build:
+    steps:
+      - name: step1
+        run: echo 1
+      - name: step2
+        run: echo 2
+"""
+    )
+    (wf_dir / "workflow2.yml").write_text(
+        """
+name: wf2
+on: [push]
+jobs:
+  build:
+    steps:
+      - name: step1
+        run: echo 1
+      - name: step2
+        run: echo 2
+"""
+    )
+    out = tmp_path / "report.md"
+    script = Path(__file__).resolve().parents[1] / "scripts" / "audit_workflows.py"
+    subprocess.run([
+        sys.executable,
+        str(script),
+        "--out",
+        str(out),
+    ], check=True, cwd=tmp_path)
+    assert out.exists()
+    assert out.read_text().count("\n") > 5


### PR DESCRIPTION
## Summary
- analyze `.github/workflows` for duplicates with `scripts/audit_workflows.py`
- test workflow audit script
- document how to run workflow audit

## Testing
- `python -m ruff check --ignore F401 .`
- `mypy --strict` *(fails: Error importing plugin `pydantic.mypy`)*
- `pytest -q` *(fails: `ModuleNotFoundError: No module named 'numpy'`)*

------
https://chatgpt.com/codex/tasks/task_e_688843b735048330864ddc376d585aac