### PR TITLE
Fix dataset badge URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 ![Python 3.8+](https://img.shields.io/badge/python-3.8%2B-blue)
 ![MIT License](https://img.shields.io/badge/license-MIT-green)
 ![Tests](https://img.shields.io/badge/tests-passing-brightgreen)
-![Dataset](https://github.com/<OWNER>/<REPO>/actions/workflows/build_dataset.yml/badge.svg)
+![Dataset](https://github.com/Yuu6798/ugh3-metrics-lib/actions/workflows/build_dataset.yml/badge.svg)
 
 # ugh3-metrics-lib
 


### PR DESCRIPTION
## Summary
- fix dataset badge to use repo's real name in README

## Testing
- `python -m ruff check --ignore F401 .`
- `mypy --strict .`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_688a21df2f048330b804c9db940ffae2