### PR TITLE
Add pip cache to CI

### DIFF
--- a/.github/actions/setup-deps/action.yml
+++ b/.github/actions/setup-deps/action.yml
@@ -18,7 +18,7 @@ runs:
       shell: bash
 
     - name: Install project (dev)
-      run: pip install --progress-bar off --no-deps -e .[dev]
+      run: pip install --progress-bar off -e .[dev]
       shell: bash
 
     - name: Clean build artifacts

--- a/.github/actions/setup-deps/action.yml
+++ b/.github/actions/setup-deps/action.yml
@@ -18,7 +18,7 @@ runs:
       shell: bash
 
     - name: Install project (dev)
-      run: pip install -e .[dev]
+      run: pip install --progress-bar off --no-deps -e .[dev]
       shell: bash
 
     - name: Clean build artifacts

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,6 +19,14 @@ jobs:
       ST_CACHE: ${{ github.workspace }}/.cache/st
     steps:
       - uses: actions/checkout@v4
+      - name: Cache pip
+        uses: actions/cache@v4
+        with:
+          path: ~/.cache/pip
+          key: >-
+            pip-${{ runner.os }}-${{ matrix.python-version }}-${{ hashFiles('pyproject.toml') }}
+          restore-keys: |
+            pip-${{ runner.os }}-${{ matrix.python-version }}-
       - uses: ./.github/actions/setup-deps
         with:
           python-version: "3.12"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,9 +24,9 @@ jobs:
         with:
           path: ~/.cache/pip
           key: >-
-            pip-${{ runner.os }}-${{ matrix.python-version }}-${{ hashFiles('pyproject.toml') }}
+            pip-${{ runner.os }}-${{ hashFiles('pyproject.toml') }}
           restore-keys: |
-            pip-${{ runner.os }}-${{ matrix.python-version }}-
+            pip-${{ runner.os }}-
       - uses: ./.github/actions/setup-deps
         with:
           python-version: "3.12"
@@ -44,15 +44,7 @@ jobs:
           grep -n "subprocess" scripts/ai_issue_codegen.py || echo "No subprocess found (good!)"
           echo "=== Checking for apply_patch calls ==="
           grep -n "apply_patch" scripts/ai_issue_codegen.py || echo "No apply_patch calls found (good!)"
-      #––– Cache pip wheels –––#
-      - name: Cache pip wheels
-        uses: actions/cache@v4
-        with:
-          path: ~/.cache/pip
-          key: >
-            pip-${{ runner.os }}-${{ hashFiles('pyproject.toml') }}
-          restore-keys: |
-            pip-${{ runner.os }}-
+
 
       #––– Cache HuggingFace models –––#
       - name: Cache HuggingFace models


### PR DESCRIPTION
## Summary
- cache pip before installing dependencies in CI
- install packages with `--progress-bar off --no-deps` in setup action

## Testing
- `python -m ruff check --ignore F401 .`
- `mypy --strict .`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688a27063d84833082d1e3bd98bd9fd0