### PR TITLE
Fix dataset workflow download step

### DIFF
--- a/.github/workflows/auto-collect.yml
+++ b/.github/workflows/auto-collect.yml
@@ -20,7 +20,7 @@ jobs:
         uses: actions/cache@v4
         with:
           path: ~/.cache/pip
-          key: pip-${{ runner.os }}-${{ hashFiles('pyproject.toml') }}
+          key: pip-${{ runner.os }}-3.11-${{ hashFiles('pyproject.toml') }}
           restore-keys: |
             pip-${{ runner.os }}-
 

--- a/.github/workflows/build_dataset.yml
+++ b/.github/workflows/build_dataset.yml
@@ -15,6 +15,14 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - uses: ./.github/actions/setup-deps
+      - name: Download raw CSV
+        run: |
+          set -euo pipefail
+          mkdir -p raw
+          curl -fsSL "$RAW_DATA_URL" | tar -xz -C raw
+          test -f raw/*.csv
+        env:
+          RAW_DATA_URL: ${{ secrets.RAW_DATA_URL }}
       - name: Build dataset
         run: python scripts/build_dataset.py
       - name: Recalculate metrics

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,7 +24,7 @@ jobs:
         with:
           path: ~/.cache/pip
           key: >-
-            pip-${{ runner.os }}-${{ hashFiles('pyproject.toml') }}
+            pip-${{ runner.os }}-3.12-${{ hashFiles('pyproject.toml') }}
           restore-keys: |
             pip-${{ runner.os }}-
       - uses: ./.github/actions/setup-deps

--- a/facade/collector.py
+++ b/facade/collector.py
@@ -18,7 +18,6 @@ import os
 import random
 import sys
 import time
-from dataclasses import asdict
 from pathlib import Path
 from typing import Any, Dict, List, Tuple
 

--- a/scripts/audit_workflows.py
+++ b/scripts/audit_workflows.py
@@ -6,7 +6,7 @@ import argparse
 import difflib
 import sys
 from pathlib import Path
-from typing import Any, Dict, List, Tuple
+from typing import Any, Dict, List
 
 import yaml
 

--- a/scripts/recalc_scores_v4.py
+++ b/scripts/recalc_scores_v4.py
@@ -20,7 +20,6 @@ import argparse
 import json
 import csv
 import logging
-import os
 import warnings
 from pathlib import Path
 import sys

--- a/tests/test_grv_yaml.py
+++ b/tests/test_grv_yaml.py
@@ -1,6 +1,5 @@
 import importlib
 
-from ugh3_metrics.metrics.grv_v4 import GrvV4
 
 
 def test_yaml_weights_loaded() -> None:

--- a/tests/test_recalc_scores_v4_internal.py
+++ b/tests/test_recalc_scores_v4_internal.py
@@ -5,7 +5,6 @@ from pathlib import Path
 
 import pytest
 
-from core.metrics import POR_FIRE_THRESHOLD
 
 
 def test_recalc_scores_v4_internal(tmp_path: Path) -> None:


### PR DESCRIPTION
## Summary
- use secret `RAW_DATA_URL` in build_dataset workflow and fail if no CSVs
- include Python version in pip cache keys

## Testing
- `ruff check .`
- `mypy .`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_688ad1ce64348330b0ad42dd6a4e10f6