### PR TITLE
AUTO: add deltae zero flagging utility

### DIFF
--- a/scripts/check_deltae_zero.py
+++ b/scripts/check_deltae_zero.py
@@ -1,5 +1,6 @@
 #!/usr/bin/env python3
 """Flag rows where delta-e is zero and record the reason."""
+# mypy: warn-unused-ignores=False
 
 from __future__ import annotations
 
@@ -48,9 +49,15 @@ def compute_reasons(df: pd.DataFrame, model: SentenceTransformer) -> pd.DataFram
         return df
 
     with torch.no_grad():
-        q_emb = model.encode(zero_rows["question"].tolist(), convert_to_tensor=True)
-        a_emb = model.encode(zero_rows["answer_a"].tolist(), convert_to_tensor=True)
-        b_emb = model.encode(zero_rows["answer_b"].tolist(), convert_to_tensor=True)
+        q_emb = model.encode(
+            zero_rows["question"].tolist(), convert_to_tensor=True
+        )  # type: ignore[call-arg]
+        a_emb = model.encode(
+            zero_rows["answer_a"].tolist(), convert_to_tensor=True
+        )  # type: ignore[call-arg]
+        b_emb = model.encode(
+            zero_rows["answer_b"].tolist(), convert_to_tensor=True
+        )  # type: ignore[call-arg]
 
     for i, idx in enumerate(zero_rows.index):
         q_vec = q_emb[i]

--- a/scripts/check_deltae_zero.py
+++ b/scripts/check_deltae_zero.py
@@ -1,0 +1,125 @@
+#!/usr/bin/env python3
+"""Flag rows where delta-e is zero and record the reason."""
+
+from __future__ import annotations
+
+import argparse
+import sys
+from pathlib import Path
+
+import numpy as np
+import pandas as pd
+import torch
+from sentence_transformers import SentenceTransformer
+
+REASON_ZERO_VECTOR = "ZERO_VECTOR"
+REASON_IDENTICAL_TEXT = "IDENTICAL_TEXT"
+REASON_UNKNOWN_CAUSE = "UNKNOWN_CAUSE"
+REQUIRED_COLUMNS = {"question", "answer_a", "answer_b", "deltae"}
+
+
+def load_dataframe(path: Path) -> pd.DataFrame:
+    """Load CSV or Parquet file into a DataFrame."""
+    if path.suffix.lower() == ".csv":
+        return pd.read_csv(path)
+    if path.suffix.lower() in {".parquet", ".parq"}:
+        return pd.read_parquet(path)
+    raise ValueError(f"Unsupported file type: {path.suffix}")
+
+
+def save_dataframe(df: pd.DataFrame, path: Path) -> None:
+    """Save DataFrame to CSV or Parquet matching the file extension."""
+    if path.suffix.lower() == ".csv":
+        df.to_csv(path, index=False)
+    else:
+        df.to_parquet(path, index=False)
+
+
+def compute_reasons(df: pd.DataFrame, model: SentenceTransformer) -> pd.DataFrame:
+    """Compute delta-e zero flags and reasons for the DataFrame."""
+    zero_mask = np.isclose(df["deltae"], 0.0)
+    flags = pd.Series(False, index=df.index, dtype=bool)
+    reasons = pd.Series([""] * len(df), index=df.index, dtype=object)
+
+    zero_rows = df[zero_mask]
+    if zero_rows.empty:
+        df["deltae_zero_flag"] = flags
+        df["deltae_zero_reason"] = reasons
+        return df
+
+    with torch.no_grad():
+        q_emb = model.encode(zero_rows["question"].tolist(), convert_to_tensor=True)
+        a_emb = model.encode(zero_rows["answer_a"].tolist(), convert_to_tensor=True)
+        b_emb = model.encode(zero_rows["answer_b"].tolist(), convert_to_tensor=True)
+
+    for i, idx in enumerate(zero_rows.index):
+        q_vec = q_emb[i]
+        a_vec = a_emb[i]
+        b_vec = b_emb[i]
+        q_norm = torch.linalg.norm(q_vec).item()
+        a_norm = torch.linalg.norm(a_vec).item()
+        b_norm = torch.linalg.norm(b_vec).item()
+        qa_cos = torch.nn.functional.cosine_similarity(q_vec, a_vec, dim=0).item()
+        ab_cos = torch.nn.functional.cosine_similarity(a_vec, b_vec, dim=0).item()
+        text_identical = (
+            df.at[idx, "question"] == df.at[idx, "answer_a"]
+            or df.at[idx, "answer_a"] == df.at[idx, "answer_b"]
+        )
+
+        if q_norm < 1e-6 or a_norm < 1e-6 or b_norm < 1e-6:
+            reason = REASON_ZERO_VECTOR
+        elif text_identical or qa_cos > 0.999 or ab_cos > 0.999:
+            reason = REASON_IDENTICAL_TEXT
+        else:
+            reason = REASON_UNKNOWN_CAUSE
+
+        flags.at[idx] = True
+        reasons.at[idx] = reason
+
+    df["deltae_zero_flag"] = flags
+    df["deltae_zero_reason"] = reasons
+    return df
+
+
+def parse_args(argv: list[str] | None) -> argparse.Namespace:
+    """Parse command line arguments."""
+    parser = argparse.ArgumentParser(description="Check delta-e zero rows.")
+    parser.add_argument("file", type=Path, help="CSV or Parquet file path")
+    return parser.parse_args(argv)
+
+
+def main(argv: list[str] | None = None) -> int:
+    """Entry point for CLI."""
+    args = parse_args(argv)
+    path = args.file
+    if not path.exists():
+        print(f"File not found: {path}", file=sys.stderr)
+        return 1
+    try:
+        df = load_dataframe(path)
+    except Exception as e:
+        print(f"Error reading file {path}: {e}", file=sys.stderr)
+        return 1
+    missing = REQUIRED_COLUMNS.difference(df.columns)
+    if missing:
+        print(f"Missing columns: {', '.join(sorted(missing))}", file=sys.stderr)
+        return 1
+    try:
+        model = SentenceTransformer("sentence-transformers/all-MiniLM-L6-v2")
+    except Exception as e:
+        print(f"Embedding model load failed: {e}", file=sys.stderr)
+        return 2
+
+    df = compute_reasons(df, model)
+    try:
+        save_dataframe(df, path)
+    except Exception as e:
+        print(f"Error saving file {path}: {e}", file=sys.stderr)
+        return 1
+
+    print(f"Wrote {len(df)} rows to {path}")
+    return 0
+
+
+if __name__ == "__main__":  # pragma: no cover
+    sys.exit(main())

--- a/tests/test_check_deltae_zero.py
+++ b/tests/test_check_deltae_zero.py
@@ -1,11 +1,19 @@
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Sequence
+
 import pandas as pd
+import pytest
 import torch
 from scripts import check_deltae_zero
 
 
 class DummyModel:
-    def encode(self, texts, convert_to_tensor=True):
-        mapping = {
+    """Minimal stand-in for SentenceTransformer."""
+
+    def encode(self, texts: Sequence[str], convert_to_tensor: bool = True) -> torch.Tensor:
+        mapping: dict[str, list[float]] = {
             "q1": [1.0, 0.0, 0.0],
             "b1": [0.0, 1.0, 0.0],
             "q2": [0.0, 0.0, 0.0],
@@ -15,7 +23,7 @@ class DummyModel:
         return torch.tensor([mapping[t] for t in texts], dtype=torch.float32)
 
 
-def run_case(tmp_path, monkeypatch, ext: str) -> None:
+def run_case(tmp_path: Path, monkeypatch: pytest.MonkeyPatch, ext: str) -> None:
     df = pd.DataFrame(
         [
             {"question": "q1", "answer_a": "q1", "answer_b": "b1", "deltae": 0.0},
@@ -42,9 +50,9 @@ def run_case(tmp_path, monkeypatch, ext: str) -> None:
     assert list(out_df["deltae_zero_reason"]) == ["IDENTICAL_TEXT", "ZERO_VECTOR", ""]
 
 
-def test_csv(tmp_path, monkeypatch):
+def test_csv(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
     run_case(tmp_path, monkeypatch, ".csv")
 
 
-def test_parquet(tmp_path, monkeypatch):
+def test_parquet(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
     run_case(tmp_path, monkeypatch, ".parquet")

--- a/tests/test_check_deltae_zero.py
+++ b/tests/test_check_deltae_zero.py
@@ -1,0 +1,50 @@
+import pandas as pd
+import torch
+from scripts import check_deltae_zero
+
+
+class DummyModel:
+    def encode(self, texts, convert_to_tensor=True):
+        mapping = {
+            "q1": [1.0, 0.0, 0.0],
+            "b1": [0.0, 1.0, 0.0],
+            "q2": [0.0, 0.0, 0.0],
+            "a2": [0.0, 0.0, 0.0],
+            "b2": [0.0, 0.0, 0.0],
+        }
+        return torch.tensor([mapping[t] for t in texts], dtype=torch.float32)
+
+
+def run_case(tmp_path, monkeypatch, ext: str) -> None:
+    df = pd.DataFrame(
+        [
+            {"question": "q1", "answer_a": "q1", "answer_b": "b1", "deltae": 0.0},
+            {"question": "q2", "answer_a": "a2", "answer_b": "b2", "deltae": 0.0},
+            {"question": "q3", "answer_a": "a3", "answer_b": "b3", "deltae": 0.5},
+        ]
+    )
+    path = tmp_path / f"data{ext}"
+    if ext == ".csv":
+        df.to_csv(path, index=False)
+    else:
+        df.to_parquet(path, index=False)
+
+    monkeypatch.setattr(check_deltae_zero, "SentenceTransformer", lambda *a, **k: DummyModel())
+    rc = check_deltae_zero.main([str(path)])
+    assert rc == 0
+
+    if ext == ".csv":
+        out_df = pd.read_csv(path, keep_default_na=False)
+    else:
+        out_df = pd.read_parquet(path)
+
+    assert list(out_df["deltae_zero_flag"]) == [True, True, False]
+    assert list(out_df["deltae_zero_reason"]) == ["IDENTICAL_TEXT", "ZERO_VECTOR", ""]
+
+
+def test_csv(tmp_path, monkeypatch):
+    run_case(tmp_path, monkeypatch, ".csv")
+
+
+def test_parquet(tmp_path, monkeypatch):
+    run_case(tmp_path, monkeypatch, ".parquet")


### PR DESCRIPTION
## Summary
- add `check_deltae_zero.py` script to flag rows with delta-e == 0 and classify reasons
- cover CSV and Parquet inputs and overwrite original files with flag columns
- add tests ensuring correct flagging and saving for both formats

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689071814d2083308c70c6a36239dfdc