### PR TITLE
AUTO: fix zero-ΔE purge pipeline

### DIFF
--- a/.github/workflows/build_dataset.yml
+++ b/.github/workflows/build_dataset.yml
@@ -6,11 +6,11 @@ on:
       purge:
         description: Purge flagged datasets
         required: false
-        default: 'false'
+        default: 'true'
       force:
         description: Skip confirmation when purging
         required: false
-        default: 'false'
+        default: 'true'
   schedule:
     - cron: "0 0 * * *"
     - cron: "0 3 * * *"
@@ -55,18 +55,17 @@ jobs:
         env:
           RAW_DATA_URL: ${{ secrets.RAW_DATA_URL }}
       - name: Scan zero-ΔE datasets
+        id: scan
         if: steps.download_raw.outputs.skip != 'true'
         run: |
-          ARGS="--min-rows 1000"
-          if [ "${{ github.event.inputs.purge }}" = "true" ]; then
-            ARGS="$ARGS --purge"
-            if [ "${{ github.event.inputs.force }}" = "true" ]; then
-              ARGS="$ARGS --force"
-            fi
-          fi
+          ARGS="--min-rows 1000 --purge --force"
           python scripts/detect_and_purge_zero_deltae.py $ARGS
+          status=$?
+          if [ "$status" -ne 0 ] && [ "$status" -ne 3 ]; then
+            exit "$status"
+          fi
       - name: Create removal PR
-        if: steps.download_raw.outputs.skip != 'true' && github.event.inputs.purge == 'true'
+        if: steps.download_raw.outputs.skip != 'true' && steps.scan.outputs.deleted != '0'
         uses: peter-evans/create-pull-request@v6
         with:
           commit-message: "remove zero-ΔE datasets (auto)"

--- a/tests/test_detect_and_purge_zero_deltae.py
+++ b/tests/test_detect_and_purge_zero_deltae.py
@@ -69,3 +69,9 @@ def test_thresholds_and_purge(
     assert half_parquet.exists()
     assert calls[0][:2] == ["git", "rm"]
     assert calls[1][:2] == ["git", "commit"]
+
+
+def test_exit_code_no_deletions(tmp_path: Path) -> None:
+    _create_files(tmp_path)
+    code = main(["--min-rows", "10", "--purge", "--force"], tmp_path)
+    assert code == 3


### PR DESCRIPTION
## Summary
- ensure zero-ΔE purge script reports deletions and exits with code 3 when none removed
- run purge with --purge --force in dataset workflow and skip PR when nothing deleted
- add unit test for exit code when no files are purged

## Testing
- `pytest -q`
- `mypy --config-file mypy.ini`

------
https://chatgpt.com/codex/tasks/task_e_6894b7cbf5508330912be7e6ff28c66b