### PR TITLE
feat: add SECL API and facade hook

### DIFF
--- a/facade/secl_hook.py
+++ b/facade/secl_hook.py
@@ -1,0 +1,27 @@
+from __future__ import annotations
+
+from typing import Any, Dict, List, Optional
+
+from core.history_entry import HistoryEntry
+from secl.api import StepInputs, StepResult, evaluate_step
+
+
+def _external_knowledge_stub() -> None:
+    """Placeholder for the external knowledge pathway."""
+    return None
+
+
+def maybe_apply_secl(
+    question: str, history: List[HistoryEntry], config: Dict[str, Any]
+) -> Optional[StepResult]:
+    """Run SECL evaluation if enabled."""
+
+    if not config.get("SECL_ENABLED", True):
+        return None
+    res = evaluate_step(StepInputs(question=question, history_list=history, config=config))
+    if res.decision == "jump":
+        _external_knowledge_stub()
+    return res
+
+
+__all__ = ["maybe_apply_secl"]

--- a/secl/api.py
+++ b/secl/api.py
@@ -1,0 +1,111 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any, Dict, List, Literal
+
+from core.history_entry import HistoryEntry
+from ugh.adapters.metrics import compute_por, compute_delta_e_embed, compute_grv_window
+
+
+@dataclass
+class StepInputs:
+    """Inputs for :func:`evaluate_step`.
+
+    Attributes
+    ----------
+    question:
+        The current question being processed.
+    history_list:
+        Existing history of steps. The latest step (if any) should be at the end.
+    config:
+        Configuration values controlling SECL behaviour.
+    """
+
+    question: str
+    history_list: List[HistoryEntry]
+    config: Dict[str, Any]
+
+
+@dataclass
+class StepResult:
+    """Result from :func:`evaluate_step`."""
+
+    updated_history: List[HistoryEntry]
+    decision: Literal["none", "jump"]
+    debug: Dict[str, Any]
+
+
+_jump_cooldown: int = 0
+
+
+def evaluate_step(inputs: StepInputs) -> StepResult:
+    """Evaluate one step and decide whether to trigger a jump.
+
+    This function computes PoR, ΔE and grv metrics for the provided question
+    and history.  It returns an updated history, a decision (``"jump"`` or
+    ``"none"``), and a dictionary of debug information.  No logging or
+    printing is performed inside this function.
+    """
+
+    global _jump_cooldown
+
+    cfg = inputs.config
+    low_por_th: float = float(cfg.get("LOW_POR_TH", 0.25))
+    high_delta_th: float = float(cfg.get("HIGH_DELTA_TH", 0.85))
+    cooldown_val: int = int(cfg.get("JUMP_COOLDOWN", 0))
+
+    question = inputs.question
+    history = inputs.history_list
+
+    # Placeholder answer; external pipeline may replace metrics by patching
+    # ``compute_por`` or ``compute_delta_e_embed`` during tests.
+    answer_stub = question
+
+    if history:
+        prev_q = history[-1].question
+        delta_e = compute_delta_e_embed(prev_q, question, answer_stub)
+    else:
+        delta_e = 0.0
+
+    por = compute_por(question, answer_stub)
+
+    temp_entry = HistoryEntry(
+        question=question,
+        answer_a=history[-1].answer_b if history else "",
+        answer_b=answer_stub,
+        por=por,
+        delta_e=delta_e,
+        grv=0.0,
+        domain="general",
+        difficulty=1,
+    )
+    grv, _ = compute_grv_window(history + [temp_entry])
+    temp_entry.grv = grv
+
+    low_por = por < low_por_th
+    high_delta = delta_e >= high_delta_th
+
+    decision: Literal["none", "jump"] = "none"
+    if _jump_cooldown > 0:
+        _jump_cooldown = max(0, _jump_cooldown - 1)
+    if low_por and high_delta and _jump_cooldown == 0:
+        decision = "jump"
+        _jump_cooldown = max(cooldown_val, 0)
+
+    updated_history = history + [temp_entry] if decision == "jump" else history
+
+    debug = {
+        "por": por,
+        "delta_e": delta_e,
+        "grv": grv,
+        "low_por": low_por,
+        "high_delta": high_delta,
+        "low_por_th": low_por_th,
+        "high_delta_th": high_delta_th,
+        "jump_cooldown": _jump_cooldown,
+    }
+
+    return StepResult(updated_history=updated_history, decision=decision, debug=debug)
+
+
+__all__ = ["StepInputs", "StepResult", "evaluate_step"]

--- a/tests/test_examples.py
+++ b/tests/test_examples.py
@@ -34,11 +34,21 @@ def test_run_cycle_generates_csv(tmp_path: Path) -> None:
     """run_cycle should create a CSV with expected columns and rows."""
     os.environ.setdefault("DELTAE4_FALLBACK", "hash")
     from facade.collector import run_cycle
+    from utils.config_loader import CONFIG
 
     (tmp_path / "datasets").mkdir(parents=True, exist_ok=True)
     out_file = tmp_path / "cycle.csv"
     steps = 2
-    run_cycle(steps, out_file, interactive=False)
+    # Disable SECL to ensure deterministic number of rows
+    prev_secl = CONFIG.get("SECL_ENABLED")
+    CONFIG["SECL_ENABLED"] = False
+    try:
+        run_cycle(steps, out_file, interactive=False)
+    finally:
+        if prev_secl is None:
+            del CONFIG["SECL_ENABLED"]
+        else:
+            CONFIG["SECL_ENABLED"] = prev_secl
 
     import csv
 

--- a/tests/test_secl_integration.py
+++ b/tests/test_secl_integration.py
@@ -1,0 +1,70 @@
+from __future__ import annotations
+
+from typing import Dict, List
+
+import pytest
+
+from core.history_entry import HistoryEntry
+from secl.api import StepInputs, StepResult, evaluate_step
+from facade.secl_hook import maybe_apply_secl
+
+
+def _patch_metrics(monkeypatch: pytest.MonkeyPatch, por: float, delta_e: float) -> None:
+    monkeypatch.setattr("secl.api.compute_por", lambda q, a, theta=0.82: por)
+    monkeypatch.setattr("secl.api.compute_delta_e_embed", lambda pq, cq, a: delta_e)
+    monkeypatch.setattr("secl.api.compute_grv_window", lambda hist: (0.1, set()))
+
+
+def _make_history() -> List[HistoryEntry]:
+    return [
+        HistoryEntry(
+            question="prev",
+            answer_a="",
+            answer_b="ans",
+            por=0.5,
+            delta_e=0.2,
+            grv=0.1,
+            domain="d",
+            difficulty=1,
+        )
+    ]
+
+
+def test_low_por_high_delta_triggers_jump(monkeypatch: pytest.MonkeyPatch) -> None:
+    _patch_metrics(monkeypatch, por=0.1, delta_e=0.9)
+    import secl.api as api
+    api._jump_cooldown = 0
+    history = _make_history()
+    cfg: Dict[str, float | int] = {"LOW_POR_TH": 0.25, "HIGH_DELTA_TH": 0.85, "JUMP_COOLDOWN": 1}
+    res = evaluate_step(StepInputs(question="cur", history_list=history, config=cfg))
+    assert res.decision == "jump"
+
+
+def test_cooldown_suppresses_repeated_jumps(monkeypatch: pytest.MonkeyPatch) -> None:
+    _patch_metrics(monkeypatch, por=0.1, delta_e=0.9)
+    import secl.api as api
+    api._jump_cooldown = 0
+    history = _make_history()
+    cfg: Dict[str, float | int] = {"LOW_POR_TH": 0.25, "HIGH_DELTA_TH": 0.85, "JUMP_COOLDOWN": 2}
+    res1 = evaluate_step(StepInputs(question="q1", history_list=history, config=cfg))
+    assert res1.decision == "jump"
+    res2 = evaluate_step(StepInputs(question="q2", history_list=res1.updated_history, config=cfg))
+    assert res2.decision == "none"
+
+
+def test_disabled_flag_bypasses_secl(monkeypatch: pytest.MonkeyPatch) -> None:
+    called = False
+
+    def fake_eval(inputs: StepInputs) -> StepResult:
+        nonlocal called
+        called = True
+        return StepResult(updated_history=inputs.history_list, decision="none", debug={})
+
+    monkeypatch.setattr("facade.secl_hook.evaluate_step", fake_eval)
+    history: List[HistoryEntry] = []
+    res = maybe_apply_secl("q", history, {"SECL_ENABLED": False})
+    assert res is None
+    assert not called
+    res = maybe_apply_secl("q", history, {"SECL_ENABLED": True})
+    assert called
+    assert isinstance(res, StepResult)


### PR DESCRIPTION
## Summary
- add public `secl.api.evaluate_step` with dataclass I/O and cooldown
- wire SECL hook into facade pipeline with optional external knowledge stub
- propagate SECL-updated history in `run_cycle` and disable SECL in CSV test
- document always advancing run-cycle state regardless of SECL decision

## Testing
- `python -m ruff check -q`
- `python -m mypy --strict --disable-error-code import-not-found .`
- `python -m pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689717220f288330a80494be384d943b