### PR TITLE
Fix ΔE fallback handling and preload embedder

### DIFF
--- a/facade/collector.py
+++ b/facade/collector.py
@@ -21,7 +21,7 @@ import time
 from pathlib import Path
 from typing import Any, Dict, List, Tuple
 
-from ugh3_metrics.metrics import DeltaE4, GrvV4, PorV4
+from ugh.adapters.metrics import DeltaE4, GrvV4, PorV4, prefetch_embed_model
 from core.history_entry import HistoryEntry
 from utils.config_loader import CONFIG
 from facade.secl_hook import maybe_apply_secl
@@ -490,6 +490,13 @@ def run_cycle(
 
 def main(argv: List[str] | None = None) -> None:
     """Command line interface for the collector."""
+    # Preload embedding model once
+    try:
+        prefetch_embed_model()
+    except Exception:
+        if os.getenv("DELTAE4_FALLBACK", "").lower() not in ("1", "true", "yes", "hash"):
+            raise
+
     parser = argparse.ArgumentParser(description="PoR/ΔE/grv collector (ばらつき付き自動生成)")
     parser.add_argument(
         "-n",

--- a/secl/api.py
+++ b/secl/api.py
@@ -4,7 +4,12 @@ from dataclasses import dataclass
 from typing import Any, Dict, List, Literal
 
 from core.history_entry import HistoryEntry
-from ugh.adapters.metrics import compute_por, compute_delta_e_embed, compute_grv_window
+from ugh.adapters.metrics import (
+    compute_por,
+    compute_delta_e_embed,
+    compute_grv_window,
+    prefetch_embed_model,
+)
 
 
 @dataclass
@@ -46,6 +51,12 @@ def evaluate_step(inputs: StepInputs) -> StepResult:
     ``"none"``), and a dictionary of debug information.  No logging or
     printing is performed inside this function.
     """
+
+    try:
+        prefetch_embed_model()
+    except Exception:
+        # ここでは握りつぶす。実際の可否は _require_model() 側で判断する。
+        pass
 
     global _jump_cooldown
 

--- a/tests/test_deltae_smoke.py
+++ b/tests/test_deltae_smoke.py
@@ -1,0 +1,12 @@
+from ugh.adapters.metrics import compute_delta_e_embed, prefetch_embed_model
+import pytest
+
+
+def test_deltae_nonzero_on_different_texts(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.delenv("DELTAE4_FALLBACK", raising=False)
+    try:
+        prefetch_embed_model()
+    except Exception as exc:  # pragma: no cover - optional path
+        pytest.skip(f"model unavailable: {exc}")
+    d = compute_delta_e_embed("犬が好き", "猫が好き", "答え")
+    assert d > 0.0


### PR DESCRIPTION
## Summary
- raise on embedding model load failure unless `DELTAE4_FALLBACK` permits a zero-value fallback
- warm the embedding model at SECL entry points to avoid cold-start delays
- include a smoke test asserting ΔE is non-zero for differing texts (skips when model unavailable)

## Testing
- `python -m ruff check -q`
- `python -m mypy --strict --disable-error-code import-not-found .`
- `python -m pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68987c2dfa98833093f8105c308df8e8