### PR TITLE
Ensure SECL step records are always appended

### DIFF
--- a/.github/workflows/nightly-collect-build-dataset.yml
+++ b/.github/workflows/nightly-collect-build-dataset.yml
@@ -13,6 +13,10 @@ env:
   STEPS: '200'          # 1 夜あたりの収集件数（必要に応じて調整）
   HF_HOME: ~/.cache/huggingface
   DELTAE4_FALLBACK: '0'  # フォールバックを無効（=埋め込み失敗時は失敗させる）
+  # --- LLM (OpenAI) ---------------------------------------------------------
+  # NOTE: リポジトリの Secrets に OPENAI_API_KEY を追加してください。
+  OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
+  OPENAI_MODEL: gpt-4o-mini
 
 jobs:
   build:
@@ -52,7 +56,7 @@ jobs:
           if [ -f requirements.txt ]; then pip install -r requirements.txt; fi
           # ライブラリ自体と必要ライブラリ
           pip install -e .
-          pip install sentence-transformers pandas pyarrow datasets
+          pip install sentence-transformers pandas pyarrow datasets openai tiktoken
 
       # === ΔE=0 の主因（コールドスタート）対策：埋め込みモデルの先読み ===
       - name: Prefetch embedding model

--- a/secl/api.py
+++ b/secl/api.py
@@ -103,7 +103,8 @@ def evaluate_step(inputs: StepInputs) -> StepResult:
         decision = "jump"
         _jump_cooldown = max(cooldown_val, 0)
 
-    updated_history = history + [temp_entry] if decision == "jump" else history
+    # 重要: jump の有無に関係なく、そのターンのレコードは必ず履歴へ追加する。
+    updated_history = history + [temp_entry]
 
     debug = {
         "por": por,


### PR DESCRIPTION
## Summary
- Record SECL evaluation for every turn regardless of jump decision
- Always merge SECL's returned history into collector's state
- Expose OpenAI API configuration and dependencies for nightly dataset collection
- Use OpenAI chat completions when API key is present, fallback to dummy otherwise
- Warn when OpenAI SDK is missing and honor optional system prompts in requests

## Testing
- `python -m ruff check -q`
- `python -m mypy --strict --disable-error-code import-not-found`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689e4a49db848330877c663eef410e73