### PR TITLE
Rebuild: robust OpenAI caller with fallbacks and AE(v4) handling

### DIFF
--- a/.github/workflows/nightly-collect-build-dataset.yml
+++ b/.github/workflows/nightly-collect-build-dataset.yml
@@ -54,9 +54,21 @@ jobs:
         run: |
           python -m pip install -U pip
           if [ -f requirements.txt ]; then pip install -r requirements.txt; fi
-          # ライブラリ自体と必要ライブラリ
           pip install -e .
-          pip install sentence-transformers pandas pyarrow datasets openai tiktoken
+          pip install "openai>=1.30.0,<2" "tiktoken>=0.7.0" sentence-transformers pandas pyarrow datasets
+
+      - name: Show dependency versions
+        run: |
+          python - <<'PY'
+          import importlib, sys
+          print("python", sys.version)
+          for name in ("openai", "tiktoken", "sentence_transformers"):
+              try:
+                  mod = importlib.import_module(name)
+                  print(name, getattr(mod, "__version__", "unknown"))
+              except Exception as e:  # pragma: no cover - best effort logging
+                  print(f"{name} unavailable ({e})")
+          PY
 
       # === ΔE=0 の主因（コールドスタート）対策：埋め込みモデルの先読み ===
       - name: Prefetch embedding model


### PR DESCRIPTION
## Summary
- Ensure nightly workflow installs pinned OpenAI and tiktoken versions and logs package versions
- Add `_env` helper, handle missing DeltaE4 gracefully, and implement OpenAI call with Client→module→dummy fallbacks
- Use safe `delta_e` computation, call OpenAI directly in run loop, and make CLI return an exit code
- Trim environment variable helper so blank values fall back to defaults
- Clarify OpenAI fallback logging and initialize DeltaE singleton outside the try block
- Resolve OpenAI model via environment-driven helper and honor non-OpenAI providers in the run loop
- Restore `AI_PROVIDER` environment fallback in `run_cycle`

## Testing
- `python -m mypy --strict --disable-error-code import-not-found`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689fef0952b08330bfb80e08ef220df4