### PR TITLE
Avoid runpy double execution in collector

### DIFF
--- a/.github/workflows/nightly-collect-build-dataset.yml
+++ b/.github/workflows/nightly-collect-build-dataset.yml
@@ -84,7 +84,9 @@ jobs:
         run: |
           set -euo pipefail
           mkdir -p "runs/${DATE}"
-          python -m facade.collector --auto -n "${STEPS}" --summary -o "runs/${DATE}/cycle.csv"
+          # runpy 由来の二重実行警告が出たら失敗させる
+          python -W "error::RuntimeWarning:runpy" -m facade.collector \
+            --auto -n "${STEPS}" --summary -o "runs/${DATE}/cycle.csv"
           test -s "runs/${DATE}/cycle.csv"
 
       # === ΔE=0 件数を計測（必要なら増し取りの足し前依頼） ===

--- a/facade/__init__.py
+++ b/facade/__init__.py
@@ -1,4 +1,7 @@
-from .trigger import por_trigger, main_qa_cycle
-from .collector import run_cycle
-
-__all__ = ["por_trigger", "main_qa_cycle", "run_cycle"]
+"""Keep package init side-effect free to avoid runpy double-execution."""
+__all__: list[str] = []
+try:
+    from importlib.metadata import version
+    __version__ = version("ugh3-metrics-lib")
+except Exception:
+    __version__ = "0"

--- a/tests/test_no_double_exec.py
+++ b/tests/test_no_double_exec.py
@@ -1,0 +1,28 @@
+import subprocess, sys, tempfile, pathlib
+
+def test_cli_single_run():
+    out = pathlib.Path(tempfile.gettempdir()) / "cycle_test.csv"
+    if out.exists():
+        out.unlink()
+    # runpy 由来の RuntimeWarning が出たら失敗
+    cp = subprocess.run(
+        [
+            sys.executable,
+            "-W",
+            "error::RuntimeWarning:runpy",
+            "-m",
+            "facade.collector",
+            "--auto",
+            "-n",
+            "1",
+            "--summary",
+            "-o",
+            str(out),
+        ],
+        capture_output=True,
+        text=True,
+    )
+    assert cp.returncode == 0, cp.stderr or cp.stdout
+    assert out.exists()
+    # 終了メッセージの重複が無いこと（Summary が1回）
+    assert cp.stdout.count("== Summary ==") <= 1

--- a/tests/test_no_double_exec.py
+++ b/tests/test_no_double_exec.py
@@ -1,28 +1,15 @@
 import subprocess, sys, tempfile, pathlib
 
-def test_cli_single_run():
+def test_cli_single_run() -> None:
     out = pathlib.Path(tempfile.gettempdir()) / "cycle_test.csv"
     if out.exists():
         out.unlink()
-    # runpy 由来の RuntimeWarning が出たら失敗
     cp = subprocess.run(
-        [
-            sys.executable,
-            "-W",
-            "error::RuntimeWarning:runpy",
-            "-m",
-            "facade.collector",
-            "--auto",
-            "-n",
-            "1",
-            "--summary",
-            "-o",
-            str(out),
-        ],
+        [sys.executable, "-W", "error::RuntimeWarning:runpy", "-m", "facade.collector",
+         "--auto", "-n", "1", "--summary", "-o", str(out)],
         capture_output=True,
         text=True,
     )
     assert cp.returncode == 0, cp.stderr or cp.stdout
     assert out.exists()
-    # 終了メッセージの重複が無いこと（Summary が1回）
     assert cp.stdout.count("== Summary ==") <= 1


### PR DESCRIPTION
## Summary
- keep facade package init side-effect free so runpy doesn't import collector
- fail GitHub workflow if runpy double-exec warning occurs
- test that collector runs once without duplicate summary output

## Testing
- `pytest -q`
- `DELTAE4_FALLBACK=hash python -W "error::RuntimeWarning:runpy" -m facade.collector --auto -n 1 --summary -o cycle_test_cli.csv`


------
https://chatgpt.com/codex/tasks/task_e_68a3717b0bcc8330b20d43f78feb0275