### PR TITLE
Ensure collector test uses embedding fallback

### DIFF
--- a/tests/test_no_double_exec.py
+++ b/tests/test_no_double_exec.py
@@ -1,3 +1,4 @@
+import os
 import subprocess, sys, tempfile, pathlib
 
 def test_cli_single_run() -> None:
@@ -9,6 +10,7 @@ def test_cli_single_run() -> None:
          "--auto", "-n", "1", "--summary", "-o", str(out)],
         capture_output=True,
         text=True,
+        env={**os.environ, "DELTAE4_FALLBACK": "hash"},
     )
     assert cp.returncode == 0, cp.stderr or cp.stdout
     assert out.exists()


### PR DESCRIPTION
## Summary
- ensure CLI collector test sets DELTAE4_FALLBACK so embeddings fallback gracefully

## Testing
- `pytest tests/test_no_double_exec.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68a461351f5c833091611f071175dc34