### PR TITLE
Align example tests with facade API and streamline dataset workflow

### DIFF
--- a/.github/workflows/nightly-collect-build-dataset.yml
+++ b/.github/workflows/nightly-collect-build-dataset.yml
@@ -10,11 +10,9 @@ permissions:
 
 env:
   PYTHON_VERSION: '3.11'
-  # Legacy knob kept for backward-compatibility. Prefer COLLECT_STEPS.
-  STEPS: '200'             # [deprecated knob] backward-compat only. Prefer COLLECT_STEPS.
-  HF_HOME: ~/.cache/huggingface
-  # 収集件数（collectorが参照）。未設定時は collector ステップが 50 を採用。
+  # 収集件数（collector が参照）。未設定時は collector 側で 50 を採用。
   COLLECT_STEPS: '50'
+  HF_HOME: ~/.cache/huggingface
   # 監査のしきい値（必要に応じて調整可能）
   AUDIT_MIN_ROWS: '40'
   AUDIT_MIN_DOMAINS: '3'
@@ -91,12 +89,15 @@ jobs:
 
       # === 収集（raw 生成） ===
       - name: Run auto collector (single run; default n=50)
+        shell: bash
         run: |
           set -euo pipefail
-          # Allow override via env.COLLECT_STEPS; fallback to 50 when unset.
-          STEPS="${COLLECT_STEPS:-50}"
+          # Allow override via env.COLLECT_STEPS; fallback to 50 when unset (pure bash expansion).
+          STEPS=${COLLECT_STEPS:-50}
+          echo "::notice title=Collector steps::n=${STEPS}"
           mkdir -p "runs/${DATE}"
           echo "[collector] run once with n=${STEPS}"
+          # Guard against runpy double-execution.
           python -W "error::RuntimeWarning:runpy" -m facade.collector \
             --auto -n "${STEPS}" --summary -o "runs/${DATE}/cycle.csv"
 
@@ -126,19 +127,16 @@ jobs:
           python - <<'PY'
           import os
           from tools.audit_dataset import main
-          csv = f"runs/{os.environ['DATE']}/cycle.csv"
-          out_json = f"runs/{os.environ['DATE']}/audit.json"
-          out_md = f"runs/{os.environ['DATE']}/audit.md"
           code = main([
-              "--csv", csv,
-              "--json", out_json,
-              "--md", out_md,
-              "--min-rows", os.getenv("AUDIT_MIN_ROWS","40"),
-              "--min-domains", os.getenv("AUDIT_MIN_DOMAINS","3"),
-              "--min-diffs", os.getenv("AUDIT_MIN_DIFFS","3"),
-              "--por-min", os.getenv("AUDIT_POR_MIN","0.80"),
-              "--ae-max", os.getenv("AUDIT_AE_MAX","0.30"),
-              "--grv-min", os.getenv("AUDIT_GRV_MIN","0.60"),
+            "--csv", f"runs/{os.environ['DATE']}/cycle.csv",
+            "--json", f"runs/{os.environ['DATE']}/audit.json",
+            "--md",   f"runs/{os.environ['DATE']}/audit.md",
+            "--min-rows",    os.getenv("AUDIT_MIN_ROWS", "40"),
+            "--min-domains", os.getenv("AUDIT_MIN_DOMAINS", "3"),
+            "--min-diffs",   os.getenv("AUDIT_MIN_DIFFS", "3"),
+            "--por-min",     os.getenv("AUDIT_POR_MIN", "0.80"),
+            "--ae-max",      os.getenv("AUDIT_AE_MAX", "0.30"),
+            "--grv-min",     os.getenv("AUDIT_GRV_MIN", "0.60"),
           ])
           raise SystemExit(code)
           PY
@@ -149,8 +147,10 @@ jobs:
         run: |
           set -euo pipefail
           EXTRA=${{ steps.zerochk.outputs.zeros }}
-          echo "Top-off ${EXTRA} rows to replace zero-ΔE records…"
-          python -m facade.collector --auto -n "${EXTRA}" --summary -o "runs/${DATE}/cycle_extra.csv"
+          echo "Top-off ${EXTRA} rows to replace zero-ΔE records (guarded single run)..."
+          python -W "error::RuntimeWarning:runpy" \
+            -m facade.collector --auto -n "${EXTRA}" --summary \
+            -o "runs/${DATE}/cycle_extra.csv"
 
       # === データセット生成（ΔE=0 を除去） ===
       - name: Build dataset (filter ΔE==0)
@@ -205,13 +205,25 @@ jobs:
           if-no-files-found: error
           retention-days: 14
 
+      # コミット対象が存在する時だけ add-and-commit を実行するガード
+      - name: Detect files to commit
+        id: git_dirty
+        shell: bash
+        run: |
+          set -euo pipefail
+          DATE="${DATE}"
+          git add -N "runs/${DATE}" "datasets/${DATE}" || true
+          if [ -n "$(git status --porcelain -- runs/${DATE} datasets/${DATE} || true)" ]; then
+            echo "dirty=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "dirty=false" >> "$GITHUB_OUTPUT"
+          fi
+
       # （任意）data ブランチへコミットしたい場合
       - name: Commit to data branch (optional)
-        if: ${{ github.event_name != 'pull_request' }}
+        if: ${{ steps.git_dirty.outputs.dirty == 'true' && github.event_name != 'pull_request' }}
         uses: EndBug/add-and-commit@v9
         with:
-          add: |
-            runs/${{ env.DATE }}/*
-            datasets/${{ env.DATE }}/*
-          message: "dataset: ${{ env.DATE }} kept=${{ steps.buildset.outputs.kept }} removed_zero=${{ steps.buildset.outputs.removed }}"
+          add: "runs/${{ env.DATE }} datasets/${{ env.DATE }}"
+          message: "dataset: ${{ env.DATE }}"
           new_branch: "data"

--- a/.gitignore
+++ b/.gitignore
@@ -74,3 +74,4 @@ backups/
 runs/
 temp_comet/
 /analysis_output/
+reports/

--- a/facade/__init__.py
+++ b/facade/__init__.py
@@ -1,7 +1,33 @@
 """Keep package init side-effect free to avoid runpy double-execution."""
-__all__: list[str] = []
+
+from __future__ import annotations
+
+# __version__ をできるだけ確実に埋める（失敗時は "0"）
 try:
-    from importlib.metadata import version
-    __version__ = version("ugh3-metrics-lib")
+    from importlib.metadata import version as _pkg_version  # type: ignore
+    __version__ = _pkg_version("ugh3-metrics-lib")
 except Exception:
-    __version__ = "0"
+    try:
+        from importlib.metadata import version as _pkg_version  # type: ignore
+        __version__ = _pkg_version("por-deltae-lib")
+    except Exception:  # pragma: no cover
+        __version__ = "0"
+
+from typing import Any, Callable, cast
+
+def collector_main(argv: list[str] | None = None) -> int:
+    """Proxy to :func:`facade.collector.main` without importing it eagerly."""
+    from .collector import main
+
+    return main(argv)
+
+
+def run_cycle(*args: Any, **kwargs: Any) -> None:
+    """Proxy to :func:`facade.collector.run_cycle` lazily."""
+    from .collector import run_cycle as _run_cycle
+
+    fn = cast(Callable[..., None], _run_cycle)
+    return fn(*args, **kwargs)
+
+
+__all__ = ["collector_main", "run_cycle", "__version__"]

--- a/tests/test_examples.py
+++ b/tests/test_examples.py
@@ -9,7 +9,8 @@ matplotlib.use("Agg")
 os.environ.setdefault("DELTAE4_FALLBACK", "hash")
 
 import phase_map_demo  # noqa: E402
-import facade.collector  # noqa: E402
+# 内部実装への直接 import は避ける（公開 API のみ）
+from facade import collector_main, run_cycle  # noqa: E402
 import secl.qa_cycle  # noqa: E402
 
 
@@ -20,7 +21,7 @@ def test_import_example_modules() -> None:
 def test_scripts_run(tmp_path: Path) -> None:
     (tmp_path / "datasets").mkdir(parents=True, exist_ok=True)
     phase_map_demo.main()
-    facade.collector.main([
+    collector_main([
         "--auto",
         "-n",
         "1",
@@ -33,7 +34,7 @@ def test_scripts_run(tmp_path: Path) -> None:
 def test_run_cycle_generates_csv(tmp_path: Path) -> None:
     """run_cycle should create a CSV with expected columns and rows."""
     os.environ.setdefault("DELTAE4_FALLBACK", "hash")
-    from facade.collector import run_cycle
+    # run_cycle は上の公開 API から import 済み
     from utils.config_loader import CONFIG
 
     (tmp_path / "datasets").mkdir(parents=True, exist_ok=True)

--- a/tests/test_no_double_exec.py
+++ b/tests/test_no_double_exec.py
@@ -1,5 +1,8 @@
 import os
-import subprocess, sys, tempfile, pathlib
+import pathlib
+import subprocess
+import sys
+import tempfile
 
 def test_cli_single_run() -> None:
     out = pathlib.Path(tempfile.gettempdir()) / "cycle_test.csv"


### PR DESCRIPTION
## Summary
- default collector step counts via `COLLECT_STEPS` and guard both runs against `RuntimeWarning:runpy`
- audit dataset in one concise call and commit outputs only when generated
- ensure examples import `collector_main` and `run_cycle` from the public `facade` API

## Testing
- `git grep -nE "from +facade +import|import +facade" || true`
- `rg -n "RuntimeWarning:runpy" .github/workflows || true`
- `rg -n "COLLECT_STEPS|STEPS" .github/workflows || true`
- `COLLECT_STEPS=50 bash -c 'echo "DEBUG COLLECT_STEPS=$COLLECT_STEPS"; STEPS="${COLLECT_STEPS:-${STEPS:-50}}"; echo "DEBUG STEPS=$STEPS"; python -m facade.collector --auto -n "${STEPS}" --summary -o runs/test/cycle.csv'` *(fails: ProxyError: Tunnel connection failed: 403 Forbidden)*
- `python -m tools.audit_dataset --csv runs/test/cycle.csv --json runs/test/audit.json --md runs/test/audit.md` *(fails: FileNotFoundError)*
- `python -m ruff .`
- `python -m mypy .`
- `python -m pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68a80e8b54408330be548f5959eb8692