### PR TITLE
Refine nightly dataset commit workflow

### DIFF
--- a/.github/workflows/nightly-collect-build-dataset.yml
+++ b/.github/workflows/nightly-collect-build-dataset.yml
@@ -236,8 +236,8 @@ jobs:
         run: |
           set -euo pipefail
           DATE="${DATE}"
-          git add -N "runs/${DATE}" "datasets/${DATE}" || true
-          if [ -n "$(git status --porcelain -- runs/${DATE} datasets/${DATE} || true)" ]; then
+          git add -N "datasets/${DATE}" || true
+          if [ -n "$(git status --porcelain -- datasets/${DATE} || true)" ]; then
             echo "dirty=true" >> "$GITHUB_OUTPUT"
           else
             echo "dirty=false" >> "$GITHUB_OUTPUT"
@@ -248,6 +248,6 @@ jobs:
         if: ${{ steps.git_dirty.outputs.dirty == 'true' && github.event_name != 'pull_request' }}
         uses: EndBug/add-and-commit@v9
         with:
-          add: "runs/${{ env.DATE }} datasets/${{ env.DATE }}"
-          message: "dataset: ${{ env.DATE }}"
+          add: datasets/${{ env.DATE }}/
+          message: "dataset: ${{ env.DATE }} kept=${{ steps.buildset.outputs.kept }} removed_zeros=${{ steps.buildset.outputs.removed }}"
           new_branch: "data"


### PR DESCRIPTION
## Summary
- commit only dataset directory in nightly workflow
- include kept and removed zero counts in commit message

## Testing
- `python -m pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68afc5eba4048330862ee09ee6658d8f