### PR TITLE
feat: unify meta handling across stats tooling

### DIFF
--- a/.github/workflows/nightly-collect-build-dataset.yml
+++ b/.github/workflows/nightly-collect-build-dataset.yml
@@ -131,6 +131,7 @@ jobs:
             "--csv", f"runs/{os.environ['DATE']}/cycle.csv",
             "--json", f"runs/{os.environ['DATE']}/audit.json",
             "--md",   f"runs/{os.environ['DATE']}/audit.md",
+            "--meta", f"datasets/{os.environ['DATE']}/meta.json",
             "--min-rows",    os.getenv("AUDIT_MIN_ROWS", "40"),
             "--min-domains", os.getenv("AUDIT_MIN_DOMAINS", "3"),
             "--min-diffs",   os.getenv("AUDIT_MIN_DIFFS", "3"),
@@ -217,6 +218,7 @@ jobs:
           code = main([
             "--csv", f"datasets/{date}/dataset.csv",
             "--outdir", out,
+            "--meta", f"datasets/{date}/meta.json",
           ])
           raise SystemExit(code)
           PY

--- a/tests/test_stats_common.py
+++ b/tests/test_stats_common.py
@@ -1,0 +1,16 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from tools.stats_common import attach_meta
+
+
+def test_attach_meta(tmp_path: Path) -> None:
+    meta = {"records_total": 10, "zeros_removed": 3, "kept": 7, "date": "T"}
+    mp = tmp_path / "meta.json"
+    mp.write_text(json.dumps(meta), encoding="utf-8")
+    payload = attach_meta({"ok": True}, csv="x.csv", meta_path=str(mp))
+    assert payload["meta"]["csv"] == "x.csv"
+    assert payload["meta"]["counts"]["kept"] == 7
+

--- a/tools/paper_report.py
+++ b/tools/paper_report.py
@@ -1,14 +1,20 @@
 from __future__ import annotations
-import argparse, json, os, hashlib
+
+import argparse
+import hashlib
+import json
 from pathlib import Path
 from typing import Any, Dict, Optional, Tuple
+
 import pandas as pd
+
+from tools.stats_common import pick_col as _pick, float_ as _float_helper, attach_meta
+
 
 # --- helpers -----------------------------------------------------------------
 def _pick_col(df: pd.DataFrame, cands: Tuple[str, ...]) -> Optional[str]:
-    for c in cands:
-        if c in df.columns: return c
-    return None
+    # delegate to shared helper (retain name for backward compatibility)
+    return _pick(df, cands)
 
 
 def _hash_q(text: str) -> str:
@@ -16,10 +22,7 @@ def _hash_q(text: str) -> str:
 
 
 def _float(x: Any, default: float = 0.0) -> float:
-    try:
-        return float(x)
-    except Exception:
-        return default
+    return _float_helper(x, default)
 
 # --- row-level stats (そのままの行 = A/B 含む) -----------------------------------
 def compute_row_stats(df: pd.DataFrame) -> Dict[str, Any]:
@@ -43,36 +46,40 @@ def compute_row_stats(df: pd.DataFrame) -> Dict[str, Any]:
 
 # --- question-level collapse (A/B を一本化) -----------------------------------
 def to_question_level(df: pd.DataFrame) -> pd.DataFrame:
-    # 必須っぽい列を柔軟に拾う
-    col_q  = _pick_col(df, ("question","prompt","input"))
-    col_a  = _pick_col(df, ("answer","answer_a","output"))
-    col_dom= _pick_col(df, ("domain","domains"))
-    col_dif= _pick_col(df, ("difficulty","difficulties"))
-    col_por= _pick_col(df, ("por","PoR"))
-    col_de = _pick_col(df, ("delta_e","ΔE","de","delta_e_"))
-    col_grv= _pick_col(df, ("grv","grv_μ","grv_mu"))
+    """Collapse A/B answers into single question-level entries."""
+    col_q = _pick_col(df, ("question", "prompt", "input"))
+    col_dom = _pick_col(df, ("domain", "domains"))
+    col_dif = _pick_col(df, ("difficulty", "difficulties"))
+    col_por = _pick_col(df, ("por", "PoR"))
+    col_de = _pick_col(df, ("delta_e", "ΔE", "de", "delta_e_"))
+    col_grv = _pick_col(df, ("grv", "grv_μ", "grv_mu"))
     if not col_q:
         raise SystemExit("question column not found")
-    # 質問キー（質問文だけでハッシュ）: A/B を同じキーに
     qkey = df[col_q].astype(str).map(_hash_q)
     g = df.assign(__qkey=qkey).groupby("__qkey", as_index=False)
-    # A/B の平均で代表値を作る（必要なら max などにも変更可）
-    agg = g.agg({
-        col_q: "first",
-        col_dom: "first" if col_dom else "size",
-        col_dif: "first" if col_dif else "size",
-        col_por: "mean" if col_por else "size",
-        col_de:  "mean" if col_de  else "size",
-        col_grv: "mean" if col_grv else "size",
-    })
-    # 列名の標準化
-    rename = {}
-    if col_q:   rename[col_q]  = "question"
-    if col_dom: rename[col_dom]= "domain"
-    if col_dif: rename[col_dif]= "difficulty"
-    if col_por: rename[col_por]= "por"
-    if col_de:  rename[col_de] = "delta_e"
-    if col_grv: rename[col_grv]= "grv"
+    agg = g.agg(
+        {
+            col_q: "first",
+            col_dom: "first" if col_dom else "size",
+            col_dif: "first" if col_dif else "size",
+            col_por: "mean" if col_por else "size",
+            col_de: "mean" if col_de else "size",
+            col_grv: "mean" if col_grv else "size",
+        }
+    )
+    rename: Dict[str, str] = {}
+    if col_q:
+        rename[col_q] = "question"
+    if col_dom:
+        rename[col_dom] = "domain"
+    if col_dif:
+        rename[col_dif] = "difficulty"
+    if col_por:
+        rename[col_por] = "por"
+    if col_de:
+        rename[col_de] = "delta_e"
+    if col_grv:
+        rename[col_grv] = "grv"
     dfq = agg.rename(columns=rename)
     return dfq
 
@@ -88,14 +95,15 @@ def compute_q_stats(dfq: pd.DataFrame) -> Dict[str, Any]:
     }
     return stats
 
-def by_category(df: pd.DataFrame, key: str) -> Dict[str, Dict[str, float]]:
+def by_category(dfq: pd.DataFrame, key: str) -> Dict[str, Dict[str, float]]:
     out: Dict[str, Dict[str, float]] = {}
-    if key not in df.columns: return out
-    for k, g in df.groupby(key):
+    if key not in dfq.columns:
+        return out
+    for k, g in dfq.groupby(key):
         out[str(k)] = {
             "count": int(len(g)),
             "por_mu": float(g["por"].mean()) if "por" in g.columns else 0.0,
-            "ae_mu":  float(g["delta_e"].mean()) if "delta_e" in g.columns else 0.0,
+            "ae_mu": float(g["delta_e"].mean()) if "delta_e" in g.columns else 0.0,
             "grv_mu": float(g["grv"].mean()) if "grv" in g.columns else 0.0,
         }
     return dict(sorted(out.items(), key=lambda x: (-x[1]["count"], x[0])))
@@ -116,11 +124,29 @@ def write_md(path: Path, payload: Dict[str, Any]) -> None:
     lines += [f"- Rows (adopted): **{rl['rows']}** / Zero-ΔE rows: **{rl['zero_de']}**"]
     lines += [f"- Questions: **{ql['questions']}**"]
     lines += [f"- Domains: rows **{rl['domains']}**, questions **{ql['domains']}**"]
-    lines += [f"- Difficulties: rows **{rl['difficulties']}**, questions **{ql['difficulties']}**", ""]
+    lines += [
+        f"- Difficulties: rows **{rl['difficulties']}**, questions **{ql['difficulties']}**",
+        "",
+    ]
     lines += ["## Means (row-level)", ""]
     lines += [f"- PoR μ: **{rl['por_mu']:.3f}**, ΔE μ: **{rl['ae_mu']:.3f}**, grv μ: **{rl['grv_mu']:.3f}**", ""]
     lines += ["## Means (question-level)", ""]
-    lines += [f"- PoR μ (Q): **{ql['por_mu_q']:.3f}**, ΔE μ (Q): **{ql['ae_mu_q']:.3f}**, grv μ (Q): **{ql['grv_mu_q']:.3f}**", ""]
+    lines += [
+        f"- PoR μ (Q): **{ql['por_mu_q']:.3f}**, ΔE μ (Q): **{ql['ae_mu_q']:.3f}**, "
+        f"grv μ (Q): **{ql['grv_mu_q']:.3f}**",
+        "",
+    ]
+    meta = s.get("meta")
+    if meta:
+        lines += ["## Meta", ""]
+        lines += [f"- csv: `{meta.get('csv', '')}`"]
+        if "counts" in meta:
+            c = meta["counts"]
+            pre = c.get("records_total", "?")
+            kept = c.get("kept", "?")
+            zero = c.get("zeros_removed", "?")
+            lines += [f"- rows (pre → post): **{pre} → {kept}** (zero-ΔE removed: {zero})"]
+        lines += [f"- date: {meta.get('date', '')}", ""]
     # domain/difficulty breakdown
     dom = s.get("by_domain_q", {})
     dif = s.get("by_difficulty_q", {})
@@ -141,7 +167,6 @@ def write_md(path: Path, payload: Dict[str, Any]) -> None:
         import matplotlib.pyplot as plt
         import matplotlib
         matplotlib.use("Agg")
-        from math import ceil
         # hist of PoR / ΔE / grv on question-level
         fig, axes = plt.subplots(1, 3, figsize=(9, 3))
         cols = [("por","PoR"), ("delta_e","ΔE"), ("grv","grv")]
@@ -153,7 +178,7 @@ def write_md(path: Path, payload: Dict[str, Any]) -> None:
         hist = path.parent / "hist_question.png"
         fig.savefig(hist, dpi=160)
         lines += ["## Histograms (question-level)", "", f"![]({hist.name})", ""]
-    except Exception as e:
+    except Exception:
         lines += ["_Note: matplotlib not available; skipped plots._", ""]
     path.parent.mkdir(parents=True, exist_ok=True)
     with path.open("w", encoding="utf-8") as f:
@@ -164,6 +189,9 @@ def main(argv: Optional[list[str]] = None) -> int:
     p = argparse.ArgumentParser(description="Build paper-ready report from dataset.csv")
     p.add_argument("--csv", required=True, help="Input dataset CSV (after filtering)")
     p.add_argument("--outdir", required=True, help="Output directory (e.g., reports/DATE)")
+    p.add_argument(
+        "--meta", required=False, default=None, help="Optional meta.json path (to show pre/post counts)."
+    )
     args = p.parse_args(argv)
     df = pd.read_csv(args.csv)
     row_stats = compute_row_stats(df)
@@ -176,9 +204,10 @@ def main(argv: Optional[list[str]] = None) -> int:
         "by_difficulty_q": by_category(dfq, "difficulty"),
         # for plotting (optional)
         "question_df_cols": {
-            k: dfq[k].tolist() for k in ("por","delta_e","grv") if k in dfq.columns
+            k: dfq[k].tolist() for k in ("por", "delta_e", "grv") if k in dfq.columns
         },
     }
+    payload = attach_meta(payload, csv=args.csv, meta_path=args.meta)
     outdir = Path(args.outdir)
     write_json(outdir / "paper_stats.json", payload)
     write_md(outdir / "paper_report.md", payload)

--- a/tools/stats_common.py
+++ b/tools/stats_common.py
@@ -1,0 +1,71 @@
+from __future__ import annotations
+
+import json
+import os
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any, Dict, Optional, Tuple
+
+import pandas as pd
+
+
+def pick_col(df: pd.DataFrame, cands: Tuple[str, ...]) -> Optional[str]:
+    """Return first column name that exists in df from candidates."""
+    for c in cands:
+        if c in df.columns:
+            return c
+    return None
+
+
+def float_(x: Any, default: float = 0.0) -> float:
+    try:
+        return float(x)
+    except Exception:  # pragma: no cover - defensive
+        return default
+
+
+def now_iso() -> str:
+    """Return current UTC time in ISO format without microseconds."""
+    return datetime.now(timezone.utc).replace(microsecond=0).isoformat()
+
+
+def attach_meta(
+    payload: Dict[str, Any], *, csv: str, meta_path: Optional[str]
+) -> Dict[str, Any]:
+    """Attach normalized meta to payload.
+
+    Parameters
+    ----------
+    payload:
+        Original payload to be extended.
+    csv:
+        Path to the CSV used to generate statistics.
+    meta_path:
+        Path to optional ``meta.json`` containing dataset build information.
+    """
+
+    out = dict(payload)
+    meta: Dict[str, Any] = {
+        "date": os.environ.get("DATE") or now_iso(),
+        "csv": csv,
+    }
+    if meta_path:
+        p = Path(meta_path)
+        meta["meta_path"] = str(p)
+        if p.exists():
+            try:
+                raw = json.loads(p.read_text(encoding="utf-8"))
+                counts = {}
+                for k in ("records_total", "zeros_removed", "kept"):
+                    if k in raw:
+                        counts[k] = int(raw[k])
+                if counts:
+                    meta["counts"] = counts
+                for k in ("date", "commit", "run_id"):
+                    if k in raw:
+                        meta[k] = raw[k]
+            except Exception:  # pragma: no cover - best effort
+                meta["counts"] = {"error": "failed_to_parse_meta"}
+    out["meta"] = meta
+    return out
+


### PR DESCRIPTION
## Summary
- factor out shared helpers for column picking, numeric casts, and meta attachment
- expose optional `--meta` on audit_dataset and paper_report, embedding meta info in JSON/Markdown
- pass dataset meta through nightly workflow and add tests for new helpers
- ensure `by_category` consistently operates on question-level DataFrames

## Testing
- `ruff .`
- `mypy`
- `pytest -q`
- `python -m tools.audit_dataset --help`
- `python -m tools.paper_report --help`


------
https://chatgpt.com/codex/tasks/task_e_68b18ef6ec848330849e8844f1711948