### PR TITLE
Add correlation and standardized OLS utilities

### DIFF
--- a/tests/test_stats_advanced.py
+++ b/tests/test_stats_advanced.py
@@ -4,7 +4,7 @@ import numpy as np
 import pandas as pd
 import pytest
 
-from tools.stats_advanced import series_summary
+from tools.stats_advanced import corr_stats, ols_standardized, series_summary
 
 
 def test_series_summary_ci() -> None:
@@ -18,3 +18,28 @@ def test_series_summary_ci() -> None:
     lo, hi = ci
     assert lo is not None and hi is not None
     assert lo < out["mean"] < hi
+
+
+def test_corr_stats() -> None:
+    rng = np.random.default_rng(0)
+    x = rng.normal(size=200)
+    y = 0.5 * x + rng.normal(scale=0.5, size=200)
+    out = corr_stats(x, y)
+    assert out["pearson"]["r"] is not None
+    assert out["spearman"]["rho"] is not None
+    assert out["pearson"]["r"] > 0.4
+    assert out["spearman"]["rho"] > 0.35
+
+
+def test_ols_standardized_smoke() -> None:
+    rng = np.random.default_rng(0)
+    n = 200
+    x1 = rng.normal(size=n)
+    x2 = rng.normal(size=n)
+    y = 1.5 * x1 + 2.0 * x2 + rng.normal(scale=0.5, size=n)
+    df = pd.DataFrame({"y": y, "x1": x1, "x2": x2})
+    res = ols_standardized(df, "y", ["x1", "x2"])
+    assert res["r2"] is not None and res["r2"] > 0.1
+    coef = res["coef"]
+    assert coef[1] > 0
+    assert coef[2] > 0


### PR DESCRIPTION
## Summary
- add corr_stats returning Pearson and Spearman correlations without SciPy dependency
- implement ols_standardized for linear regression with optional Z-scoring
- render standardized OLS regression tables in paper_report with flexible dict/array handling including `colnames`
- test correlation and standardized OLS helpers

## Testing
- `python -m mypy tools/stats_common.py tools/paper_report.py tools/stats_advanced.py tests/test_stats_advanced.py`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68ba9e43c1f083309674051612e48cbf