### PR TITLE
Add correlation and standardized OLS utilities

### DIFF
--- a/tests/test_stats_advanced.py
+++ b/tests/test_stats_advanced.py
@@ -5,6 +5,7 @@ import pandas as pd
 import pytest
 
 from tools.stats_advanced import corr_stats, ols_standardized, series_summary
+from tools.paper_report import _pick
 
 
 def test_series_summary_ci() -> None:
@@ -43,3 +44,10 @@ def test_ols_standardized_smoke() -> None:
     coef = res["coef"]
     assert coef[1] > 0
     assert coef[2] > 0
+
+
+def test_pick_handles_array_like() -> None:
+    arr = np.array([1.0, 2.0, 3.0])
+    ser = pd.Series([4.0, 5.0, 6.0])
+    assert _pick(arr, 1, "coef") == pytest.approx(2.0)
+    assert _pick(ser, 2, "coef") == pytest.approx(6.0)

--- a/tools/paper_report.py
+++ b/tools/paper_report.py
@@ -6,6 +6,7 @@ import json
 from pathlib import Path
 from typing import Any, Dict, Optional, Sequence, Tuple
 
+import numpy as np
 import pandas as pd
 
 from tools.stats_common import pick_col as _pick_col_impl, float_ as _float_helper, attach_meta
@@ -30,7 +31,11 @@ def _pick(v: Any, i: int, key: str) -> float:
     try:
         if isinstance(v, dict):
             x = v.get(key, float("nan"))
+        elif isinstance(v, (np.ndarray, pd.Series)):
+            x = v[i] if i < len(v) else float("nan")
         elif isinstance(v, Sequence):
+            x = v[i] if i < len(v) else float("nan")
+        elif hasattr(v, "__len__") and hasattr(v, "__getitem__"):
             x = v[i] if i < len(v) else float("nan")
         else:
             return float("nan")


### PR DESCRIPTION
## Summary
- support NumPy arrays and pandas Series in regression picker to avoid NaN coefficients
- add regression test ensuring array-like outputs are indexed correctly

## Testing
- `python -m mypy tools/stats_common.py tools/paper_report.py tools/stats_advanced.py tests/test_stats_advanced.py`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68baeec80dd4833096c2dcd5d7ef3d26