### PR TITLE
docs: add canonical compatibility note with ugh-audit-core

### DIFF
--- a/CANONICAL_COMPATIBILITY.md
+++ b/CANONICAL_COMPATIBILITY.md
@@ -1,0 +1,18 @@
+# Canonical Compatibility
+
+This repository preserves PoR/ΔE/grv as theoretical concepts.
+
+For production-compatible scoring and verdict behavior, the canonical
+operational contract is defined in:
+
+- `Yuu6798/ugh-audit-core/docs/canonical_metrics_contract.md`
+
+Rules for this repository:
+
+- Non-operational formulas must be treated as `research_variant`.
+- Do not expose incompatible formulas as plain `delta_e` without a mode tag.
+- Emit explicit method metadata when needed:
+  - `metric_mode`
+  - `delta_e_method`
+  - `por_method`
+  - `grv_method`


### PR DESCRIPTION
## Summary
- add `CANONICAL_COMPATIBILITY.md`
- clarify that PoR/ΔE/grv theory is preserved
- define `ugh-audit-core` as canonical operational contract
- require explicit method tags for research variants (`metric_mode`, `*_method`)

## Why
To keep theoretical definitions while preventing operational ambiguity across repositories.

## Scope
Documentation only (no runtime behavior change).